### PR TITLE
Added force to ifThenElse builtin.

### DIFF
--- a/tests/failing
+++ b/tests/failing
@@ -14,6 +14,9 @@ tests/simple/delay.uplc
 tests/simple/force.uplc
 # Var uses a free-varaible therefore it fails.
 tests/simple/var.uplc
+# ifThenElse needs to be composed with force
+# We need to improve error report to cope with `uplc` output.
+tests/simple/ifThenElse-no-force.uplc
 #
 # UPLC examples 
 #

--- a/tests/simple/ifThenElse-no-force.uplc
+++ b/tests/simple/ifThenElse-no-force.uplc
@@ -1,0 +1,1 @@
+(program 1.0.0 [ [ [ (builtin ifThenElse) (con bool True) ] (con integer 0) ] (con integer 1) ])

--- a/uplc-polymorphic-builtins.md
+++ b/uplc-polymorphic-builtins.md
@@ -20,7 +20,7 @@ module UPLC-POLYMORPHIC-BUILTINS
                     ListItem(_V1:Value)
                     ListItem(V2:Value)) => .List) </args>
 
-  rule <k> (builtin ifThenElse) => #ITE ... </k>
+  rule <k> (builtin ifThenElse) ~> Force => #ITE ... </k>
 
   rule <k> (V:Value ~> ([ Clos(#ITE, _RHO) _])) => #ITE(V) ... </k>
 


### PR DESCRIPTION
The draft semantics of UPLC of Jan 27th requires every polymorphic builtin to be composed with `force` when applied. This PR adds this. 