### PR TITLE
Transform uncurried application into curried.

### DIFF
--- a/uplc-semantics.md
+++ b/uplc-semantics.md
@@ -27,22 +27,17 @@ module UPLC-SEMANTICS
 
   rule <k> [ M N ] => M ~> [_ N] ... </k>
 
+  rule <k> [ M N:Term .TermList ] => [ M N ] </k>
+
+  rule <k> [ M N:Term T:TermList ] => [ [ M N ] T ] </k> [owise]
+
   rule <k> V:Value ~> [_ N] => N ~> [ Clos(V, RHO) _] ... </k>
        <env> RHO </env>
 
   rule <k> (V:Value ~> ([ Clos((lam X:Id M:Term), RHO') _] )) => M ... </k>
-        <env> RHO => (RHO' (X |-> Clos(V, RHO))) </env>
+       <env> RHO => (RHO' (X |-> Clos(V, RHO))) </env>
 
   rule <k> (delay M:Term) ~> Force => M ... </k>
-```
-
-## Builtin evaluation for non-partial (uncurried) application style
-
-```k
-  rule <k> (builtin BN (M Ms)) => M ~> (builtin BN Ms) ... </k> 
-
-  rule <k> V:Value ~> (builtin BN Ms) => (builtin BN Ms) ... </k>
-       <args> ... (.List => ListItem(V)) </args>
 ```
 
 ```k

--- a/uplc-syntax.md
+++ b/uplc-syntax.md
@@ -26,11 +26,11 @@ module UPLC-CONCRETE-SYNTAX
 
   syntax Term ::= Id
                 | Value
-                | "[" Term Term "]"                     // function application
-                | "(" "force" Term ")"                  // force execution of a term
+                | "[" Term TermList "]"
+                | "(" "force" Term ")"
                 | "(" "builtin" BuiltinName ")"
-                | "(" "builtin" BuiltinName TermList ")"// builtin
-                | "(" "error" ")"                       // error
+                | "(" "builtin" BuiltinName TermList ")"
+                | "(" "error" ")"
 
   syntax Value ::= "(" "con" TypeConstant Constant ")"
                  | "(" "lam" Id Term ")"


### PR DESCRIPTION
The syntax for non-partial application (uncurried) was wrong. It was `(builtin bn t1 ... tn)` but it should be `[(buintin bn) t1 ... tn ]`. This PR fixes in a series of commits starting from application syntax to the removal of unnecessary rules in all files. 