### PR TITLE
Move definitions from syntax to configuration module 

### DIFF
--- a/uplc-configuration.md
+++ b/uplc-configuration.md
@@ -27,6 +27,13 @@ to evaluate builtin arguments when the uncurried style us used, and
 builtin.
 
 ```k 
+
+  syntax Program ::= #handleProgram(Program) [function]
+                   | Bytes
+
+  rule #handleProgram(C:ConcreteProgram) => C
+  rule #handleProgram(F:FlatProgram) => String2Bytes(trimByteString({F}:>ByteString))
+
   configuration <k> #handleProgram($PGM:Program) </k>
                 <env> .Map </env>
                 <trace> .List </trace>

--- a/uplc-syntax.md
+++ b/uplc-syntax.md
@@ -15,9 +15,9 @@ module UPLC-CONCRETE-SYNTAX
   syntax FlatProgram ::= ByteString
 
   syntax Program ::= ConcreteProgram
-                 | FlatProgram
-                 | #handleProgram(Program) [function]
-                 | Bytes
+                   | FlatProgram
+                   | #handleProgram(Program) [function]
+                   | Bytes
 
   rule #handleProgram(C:ConcreteProgram) => C
   rule #handleProgram(F:FlatProgram) => String2Bytes(trimByteString({F}:>ByteString))

--- a/uplc-syntax.md
+++ b/uplc-syntax.md
@@ -11,16 +11,14 @@ module UPLC-CONCRETE-SYNTAX
   imports UPLC-BYTESTRING
   imports STRING
 
-  syntax ConcreteProgram ::= "(" "program" Version Term ")"
-  syntax FlatProgram ::= ByteString
 
   syntax Program ::= ConcreteProgram
                    | FlatProgram
-                   | #handleProgram(Program) [function]
-                   | Bytes
 
-  rule #handleProgram(C:ConcreteProgram) => C
-  rule #handleProgram(F:FlatProgram) => String2Bytes(trimByteString({F}:>ByteString))
+
+  syntax ConcreteProgram ::= "(" "program" Version Term ")"
+
+  syntax FlatProgram ::= ByteString
 
   syntax Version ::= r"[0-9]+.[0-9]+.[0-9]+" [token]
 


### PR DESCRIPTION
This pull request contains several small changes that cleans up the flat parser syntax.