### PR TITLE
Add support for fstPair and sndPair. Add one example for each builtin.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,7 @@ update-results: CONTINUE=;
 
 # Conformance tests
 #
-# Any test that is executed by `kplc run` uses invokes krun. Since the semantics is meant to
+# Any test that is executed by `kplc run` invokes krun. Since the semantics is meant to
 # conform the execution of the reference implementation, all output from `kplc run` needs to be
 # compared to tests that use krun needs to the output of the reference implementation. The
 # reference interpreter is a program maintained by IOG called uplc. 

--- a/tests/simple/fstPairOfPairAndList.uplc
+++ b/tests/simple/fstPairOfPairAndList.uplc
@@ -1,0 +1,5 @@
+(program 0.0.0
+  [(force (builtin fstPair))
+   (con pair (bool) (bytestring)
+        (True, #012345))]
+)

--- a/tests/simple/fstPairOfPairAndList.uplc.krun.expected
+++ b/tests/simple/fstPairOfPairAndList.uplc.krun.expected
@@ -1,0 +1,11 @@
+<generatedTop>
+  <k>
+    ( con bool True ) ~> .
+  </k>
+  <env>
+    .Map
+  </env>
+  <trace>
+    .List
+  </trace>
+</generatedTop>

--- a/tests/simple/pairOfPairAndList.uplc
+++ b/tests/simple/pairOfPairAndList.uplc
@@ -3,4 +3,4 @@
      pair (pair (bool) (bytestring)) (list(integer))
      ((True, #012345), [0, 1, 2])
   )
-)
+) 

--- a/tests/simple/sndPairOfPairAndList.uplc
+++ b/tests/simple/sndPairOfPairAndList.uplc
@@ -1,0 +1,5 @@
+(program 0.0.0
+  [(force (builtin sndPair))
+   (con pair (bool) (bytestring)
+        (True, #012345))]
+)

--- a/tests/simple/sndPairOfPairAndList.uplc.krun.expected
+++ b/tests/simple/sndPairOfPairAndList.uplc.krun.expected
@@ -1,0 +1,11 @@
+<generatedTop>
+  <k>
+    ( con bytestring #012345 ) ~> .
+  </k>
+  <env>
+    .Map
+  </env>
+  <trace>
+    .List
+  </trace>
+</generatedTop>

--- a/uplc-polymorphic-builtins.md
+++ b/uplc-polymorphic-builtins.md
@@ -74,6 +74,27 @@ module UPLC-POLYMORPHIC-BUILTINS
 
 ```
 
+## `fstPair`
+
+```k
+  rule <k> (builtin fstPair) ~> Force => #FPR ... </k>
+
+  rule <k> (V:Value ~> ([ Clos(#FPR, _RHO) _])) => #FPR(V) ... </k>
+
+  rule <k> #FPR((con pair (T1:TypeConstant) (_T2:TypeConstant)
+                          (C1:Constant, _C2:Constant))) => (con T1 C1) ... </k>
+```
+
+## `sndPair`
+
+```k
+  rule <k> (builtin sndPair) ~> Force => #SPR ... </k>
+
+  rule <k> (V:Value ~> ([ Clos(#SPR, _RHO) _])) => #SPR(V) ... </k>
+
+  rule <k> #SPR((con pair (_T1:TypeConstant) (T2:TypeConstant)
+                          (_C1:Constant, C2:Constant))) => (con T2 C2) ... </k>
+```
 
 ```k
 endmodule

--- a/uplc-syntax.md
+++ b/uplc-syntax.md
@@ -65,8 +65,6 @@ module UPLC-CONCRETE-SYNTAX
   syntax DataList ::= List{TextualData, ","}
   syntax DataPair ::= "(" TextualData "," TextualData ")"
   syntax DataPairList ::= List{DataPair, ","}
-
-
 ```
 
 ### Builtin Functions for Integers
@@ -403,6 +401,20 @@ module UPLC-ABSTRACT-SYNTAX
                  | #CDT(Value, Value, Value, Value)
                  | #CDT(Value, Value, Value, Value, Value)
                  | #CDT(Value, Value, Value, Value, Value, Value)
+```
+
+## For `fstPair`
+
+```k
+                 | "#FPR"
+                 | #FPR(Value)
+```
+
+## For `sndPair`
+
+```k
+                 | "#SPR"
+                 | #SPR(Value)
 ```
 
 ```k 


### PR DESCRIPTION
Builtins ' fstPair'  and 'sndPair'  are polymorphic builtins that are applied to terms such as `(con pair (integer)(bytestring) (0, #AF))`. Their denotation is the first and second projections of a pair.