### PR TITLE
Suggests a change on the syntax for data.

### DIFF
--- a/uplc-syntax.md
+++ b/uplc-syntax.md
@@ -52,7 +52,7 @@ module UPLC-CONCRETE-SYNTAX
                     | "()"
                     | "[" ConstantList "]"
                     | "(" Constant "," Constant ")"
-                    | "{" TextualData "}"
+                    | Data
 
   syntax ConstantList ::= List{Constant, ","}
 
@@ -62,11 +62,10 @@ module UPLC-CONCRETE-SYNTAX
                        | "Integer" Int
                        | "ByteString" ByteString
 
-  syntax DataList ::= List{TextualData, ","}
-  syntax DataPair ::= "(" TextualData "," TextualData ")"
+  syntax Data ::= "{" TextualData "}"
+  syntax DataList ::= List{Data, ","}
+  syntax DataPair ::= "(" Data "," Data ")"
   syntax DataPairList ::= List{DataPair, ","}
-
-
 ```
 
 ### Builtin Functions for Integers
@@ -391,6 +390,14 @@ module UPLC-ABSTRACT-SYNTAX
                  | "#CUT" 
                  | #CUT(Value)
                  | #CUT(Value, Value)
+```
+
+## For `constrData`
+
+```k
+                 | "#CND" 
+                 | #CND(Value)
+                 | #CND(Value, Value)
 ```
 
 ```k 


### PR DESCRIPTION
The syntax proposed by PR #101 creates two different forms of lists of data: i. `[ ConstantList ]` and ii. `DataList`.  An example of a term in the former is `[ { Integer 0 } , { Integer 1 } ]` while the same list in the latter would be written `[Integer 0, Integer 1] `. This implies two different ways for declaring the same thing, even though the latter is only used as argument to `Constr` terms in `TextualData`. This is undesirable. For instance, semantic rules need to coerce between the two syntactic sorts. (This is the case in the `constrData` builtin for instance.) In this PR, we propose a minor change in the syntax that does not solve the problem completely, as there are still two different syntactic sort for lists of data, but at least it unifies the notation used in both. But perhaps the main objective of this PR is to discuss whether to keep syntax the way it is or not.
 