### PR TITLE
Add trace builtin.

### DIFF
--- a/tests/simple/trace.uplc
+++ b/tests/simple/trace.uplc
@@ -1,0 +1,1 @@
+(program 0.0.0 [[(force (builtin trace)) (con string "Ola")] (con integer 2)])

--- a/tests/simple/trace.uplc.expected
+++ b/tests/simple/trace.uplc.expected
@@ -1,0 +1,1 @@
+(con integer 2)

--- a/tests/simple/trace.uplc.krun.expected
+++ b/tests/simple/trace.uplc.krun.expected
@@ -1,0 +1,11 @@
+<generatedTop>
+  <k>
+    ( con integer 2 ) ~> .
+  </k>
+  <env>
+    .Map
+  </env>
+  <trace>
+    ListItem ( "Ola" )
+  </trace>
+</generatedTop>

--- a/uplc-polymorphic-builtins.md
+++ b/uplc-polymorphic-builtins.md
@@ -158,6 +158,19 @@ module UPLC-POLYMORPHIC-BUILTINS
   rule <k> #NLT(_V:Value) => (con bool False) </k> [owise]
 ```
 
+## `trace`
+
+```k
+  rule <k> (builtin trace) ~> Force => #TRC ... </k>
+
+  rule <k> (V:Value ~> ([ Clos(#TRC, _RHO) _])) => #TRC(V) ... </k>
+
+  rule <k> (V2:Value ~> ([ Clos(#TRC(V1:Value), _RHO) _])) => #TRC(V1, V2) ... </k>
+
+  rule <k> #TRC((con string S), V:Value) => V </k>
+       <trace> ... (.List => ListItem(S)) </trace>
+```
+
 ```k
 endmodule
 ``` 

--- a/uplc-syntax.md
+++ b/uplc-syntax.md
@@ -455,6 +455,14 @@ module UPLC-ABSTRACT-SYNTAX
                  | #NLT(Value)
 ```
 
+## For `trace`
+
+```k
+                 | "#TRC"
+                 | #TRC(Value)
+                 | #TRC(Value, Value)
+```
+
 ```k 
 endmodule
 ```


### PR DESCRIPTION
This PR is essentially #121 but with a different Makefile where the command line for test does not use `krun` `--output program` but rather a sed command that removes all `.*List` constants, denoting empty lists. As shown in PR #121, `--output program` raises an exception for `trace.uplc` UPLC program.