### PR TITLE
Replaced #if#then#else#fi with rules to avoid haskell backend loop. 

### DIFF
--- a/uplc-bytestring-builtins.md
+++ b/uplc-bytestring-builtins.md
@@ -85,12 +85,11 @@ module UPLC-BYTESTRING-BUILTINS
 
   rule <k> (V2:Value ~> ([ Clos(#EBS(V1:Value), _RHO) _])) => #EBS(V1, V2) ... </k>
 
-  rule <k> #EBS((con bytestring B1:ByteString), (con bytestring B2:ByteString)) =>
-           (con bool
-	    #if (#equalsByteString(B1, B2) ==Bool true)
-	    #then (True)
-	    #else (False)
-	    #fi) ... </k>
+  rule <k> #EBS((con bytestring B1:ByteString), (con bytestring B2:ByteString)) => (con bool True) ... </k>
+  requires #equalsByteString(B1, B2)
+
+  rule <k> #EBS(_,_) => (con bool False) ... </k> [owise]
+
 ```
 
 ## `lessThanByteString`
@@ -102,12 +101,10 @@ module UPLC-BYTESTRING-BUILTINS
 
   rule <k> (V2:Value ~> ([ Clos(#LTBS(V1:Value), _RHO) _])) => #LTBS(V1, V2) ... </k>
 
-  rule <k> #LTBS((con bytestring B1:ByteString), (con bytestring B2:ByteString)) =>
-           (con bool
-	    #if (#lessThanByteString(B1, B2) ==Bool true)
-	    #then (True)
-	    #else (False)
-	    #fi) ... </k>
+  rule <k> #LTBS((con bytestring B1:ByteString), (con bytestring B2:ByteString)) => (con bool True) ... </k>
+  requires #lessThanByteString(B1, B2)
+
+  rule <k> #LTBS(_,_) => (con bool False) ... </k> [owise]
 ```
 
 ## `lessThanEqualsByteString`
@@ -119,12 +116,10 @@ module UPLC-BYTESTRING-BUILTINS
 
   rule <k> (V2:Value ~> ([ Clos(#LEBS(V1:Value), _RHO) _])) => #LEBS(V1, V2) ... </k>
 
-  rule <k> #LEBS((con bytestring B1:ByteString), (con bytestring B2:ByteString)) =>
-           (con bool
-	    #if (#lessThanEqualsByteString(B1, B2) ==Bool true)
-	    #then (True)
-	    #else (False)
-	    #fi) ... </k>
+  rule <k> #LEBS((con bytestring B1:ByteString), (con bytestring B2:ByteString)) => (con bool True) ... </k>
+  requires #lessThanEqualsByteString(B1, B2)
+
+  rule <k> #LEBS(_,_) => (con bool False) ... </k> [owise]
 ```
 
 ```k

--- a/uplc-crypto-builtins.md
+++ b/uplc-crypto-builtins.md
@@ -44,7 +44,7 @@ a ByteString.
   rule <k> (V:Value ~> ([ Clos(#SHA3, _RHO) _])) => #SHA3(V) ... </k>
 
   rule <k> #SHA3((con bytestring B:ByteString)) =>
-           (con bytestring unTrimByteString(Sha3_256(encode(B)))) </k>
+           (con bytestring unTrimByteString(Sha3_256(encode(B)))) ... </k>
 ```
 
 ## `sha2_256`
@@ -57,7 +57,7 @@ The same steps of `sha3_256` are taken to produce the proper string argument for
   rule <k> (V:Value ~> ([ Clos(#SHA2, _RHO) _])) => #SHA2(V) ... </k>
 
   rule <k> #SHA2((con bytestring B:ByteString)) =>
-           (con bytestring unTrimByteString(Sha256(encode(B)))) </k>
+           (con bytestring unTrimByteString(Sha256(encode(B)))) ... </k>
 ```
 
 ## `blake2b_256`
@@ -70,7 +70,7 @@ The same steps of `sha3_256` are taken to produce the proper string argument for
   rule <k> (V:Value ~> ([ Clos(#BLK2B, _RHO) _])) => #BLK2B(V) ... </k>
 
   rule <k> #BLK2B((con bytestring B:ByteString)) =>
-           (con bytestring unTrimByteString(Blake2b256(encode(B)))) </k>
+           (con bytestring unTrimByteString(Blake2b256(encode(B)))) ... </k>
 ```
 
 ## `verifySignature`
@@ -82,14 +82,16 @@ The same steps of `sha3_256` are taken to produce the proper string argument for
 
   rule <k> (V2:Value ~> ([ Clos(#VSIG(V1:Value), _RHO) _])) => #VSIG(V1, V2) ... </k>
 
-  rule <k> (V3:Value ~> ([ Clos(#VSIG(V1:Value, V2:Value), _RHO) _])) => #VSIG(V1, V2, V3) ... </k>
+  rule <k> (V3:Value ~> ([ Clos(#VSIG(V1:Value, V2:Value), _RHO) _])) =>
+           #VSIG(V1, V2, V3) ... </k>
 
-  rule <k> #VSIG((con bytestring K:ByteString), (con bytestring M:ByteString), (con bytestring S:ByteString)) =>
-           #if ED25519VerifyMessage(encode(K), encode(M), encode(S))
-           #then (con bool True)
-           #else (con bool False)
-           #fi
+  rule <k> #VSIG((con bytestring K:ByteString),
+                 (con bytestring M:ByteString),
+                 (con bytestring S:ByteString)) => (con bool True) ...
        </k>
+  requires ED25519VerifyMessage(encode(K), encode(M), encode(S))
+
+  rule <k> #VSIG(_,_,_) => (con bool False) ... </k> [owise]
 ```
 
 ```k

--- a/uplc-integer-builtins.md
+++ b/uplc-integer-builtins.md
@@ -1,7 +1,7 @@
 # UPLC Integer builtins
 
 ```k
-requires "uplc-configuration.md"
+require "uplc-configuration.md"
 
 module UPLC-INTEGER-BUILTINS
   imports UPLC-CONFIGURATION
@@ -127,9 +127,7 @@ It cooresponds to Haskell rem, according to Plutus specification. From Haskell d
            (con integer (I1 -Int (I1 /Int I2) *Int I2)) ... </k>
   requires I2 =/=Int 0
 
-  rule <k> #REM((con integer _I1:Int), (con integer I2:Int)) =>
-           (error) ... </k>
-  requires I2 ==Int 0
+  rule <k> #REM(_,_) => (error) ... </k> [owise]
 ```
 
 ## `lessThanInteger`
@@ -141,8 +139,10 @@ It cooresponds to Haskell rem, according to Plutus specification. From Haskell d
 
   rule <k> (V2:Value ~> ([ Clos(#LTI(V1:Value), _RHO) _])) => #LTI(V1, V2) ... </k>
 
-  rule <k> #LTI((con integer I1:Int), (con integer I2:Int)) =>
-           (#if I1 <Int I2 #then (con bool True) #else (con bool False) #fi) ... </k>
+  rule <k> #LTI((con integer I1:Int), (con integer I2:Int)) => (con bool True) ... </k>
+  requires I1 <Int I2
+
+  rule <k> #LTI(_,_) => (con bool False) ... </k> [owise]
 ```
 
 ## `lessThanEqualsInteger`
@@ -154,8 +154,10 @@ It cooresponds to Haskell rem, according to Plutus specification. From Haskell d
 
   rule <k> (V2:Value ~> ([ Clos(#LTE(V1:Value), _RHO) _])) => #LTE(V1, V2) ... </k>
 
-  rule <k> #LTE((con integer I1:Int), (con integer I2:Int)) =>
-           (#if I1 <=Int I2 #then (con bool True) #else (con bool False) #fi) ... </k>
+  rule <k> #LTE((con integer I1:Int), (con integer I2:Int)) => (con bool True) ... </k>
+  requires I1 <=Int I2
+
+  rule <k> #LTE(_,_) => (con bool False) ... </k> [owise]
 ```
 
 ## `equalsInteger`
@@ -166,8 +168,10 @@ It cooresponds to Haskell rem, according to Plutus specification. From Haskell d
 
   rule <k> (V2:Value ~> ([ Clos(#EQI(V1:Value), _RHO) _])) => #EQI(V1, V2) ... </k>
 
-  rule <k> #EQI((con integer I1:Int), (con integer I2:Int)) =>
-           (#if I1 >=Int I2 #then (con bool True) #else (con bool False) #fi) ... </k>
+  rule <k> #EQI((con integer I1:Int), (con integer I2:Int)) => (con bool True) ... </k>
+  requires I1 >=Int I2 
+
+  rule <k> #EQI(_,_) => (con bool False) ... </k> [owise]
 ```
 
 ```k 

--- a/uplc-polymorphic-builtins.md
+++ b/uplc-polymorphic-builtins.md
@@ -121,7 +121,7 @@ module UPLC-POLYMORPHIC-BUILTINS
 
   rule <k> (V2:Value ~> ([ Clos(#MCN(V1:Value), _RHO) _])) => #MCN(V1, V2) ... </k>
 
-  rule <k> #MCN((con T:TypeConstant C:Constant), (con list(T:TypeConstant) [ L:ConstantList ])) => (con list(T:TypeConstant) [ C , L ]) </k>
+  rule <k> #MCN((con T:TypeConstant C:Constant), (con list(T:TypeConstant) [ L:ConstantList ])) => (con list(T:TypeConstant) [ C , L ]) ... </k>
 ```
 
 ## `headList`
@@ -131,7 +131,7 @@ module UPLC-POLYMORPHIC-BUILTINS
 
   rule <k> (V:Value ~> ([ Clos(#HLT, _RHO) _])) => #HLT(V) ... </k>
 
-  rule <k> #HLT((con list(T:TypeConstant) [ C:Constant  , _L:ConstantList ])) => (con T C) </k>
+  rule <k> #HLT((con list(T:TypeConstant) [ C:Constant  , _L:ConstantList ])) => (con T C) ... </k>
 ```
 
 ## `tailList`
@@ -141,9 +141,9 @@ module UPLC-POLYMORPHIC-BUILTINS
 
   rule <k> (V:Value ~> ([ Clos(#TLT, _RHO) _])) => #TLT(V) ... </k>
 
-  rule <k> #TLT((con list(T:TypeConstant) [ .ConstantList ])) => (con T [ .ConstantList ]) </k>
+  rule <k> #TLT((con list(T:TypeConstant) [ .ConstantList ])) => (con T [ .ConstantList ]) ... </k>
 
-  rule <k> #TLT((con list(T:TypeConstant) [ _C:Constant , L:ConstantList ])) => (con T [ L ]) </k>
+  rule <k> #TLT((con list(T:TypeConstant) [ _C:Constant , L:ConstantList ])) => (con T [ L ]) ... </k>
 ```
 
 ## `nullList`
@@ -153,9 +153,9 @@ module UPLC-POLYMORPHIC-BUILTINS
 
   rule <k> (V:Value ~> ([ Clos(#NLT, _RHO) _])) => #NLT(V) ... </k>
 
-  rule <k> #NLT((con list(_T:TypeConstant) [ .ConstantList ])) => (con bool True) </k>
+  rule <k> #NLT((con list(_T:TypeConstant) [ .ConstantList ])) => (con bool True) ... </k>
 
-  rule <k> #NLT(_V:Value) => (con bool False) </k> [owise]
+  rule <k> #NLT(_V:Value) => (con bool False) ... </k> [owise]
 ```
 
 ## `trace`
@@ -167,7 +167,7 @@ module UPLC-POLYMORPHIC-BUILTINS
 
   rule <k> (V2:Value ~> ([ Clos(#TRC(V1:Value), _RHO) _])) => #TRC(V1, V2) ... </k>
 
-  rule <k> #TRC((con string S), V:Value) => V </k>
+  rule <k> #TRC((con string S), V:Value) => V ... </k>
        <trace> ... (.List => ListItem(S)) </trace>
 ```
 

--- a/uplc-string-builtins.md
+++ b/uplc-string-builtins.md
@@ -20,7 +20,7 @@ module UPLC-STRING-BUILTINS
   rule <k> (V:Value ~> ([ Clos(#EUTF, _RHO) _])) => #EUTF(V) ... </k>
 
   rule <k> #EUTF((con string S:String)) =>
-           (con bytestring #encodeUtf8(S)) </k>
+           (con bytestring #encodeUtf8(S)) ... </k>
 ```
 
 ## `decodeUtf8`
@@ -31,7 +31,7 @@ module UPLC-STRING-BUILTINS
   rule <k> (V:Value ~> ([ Clos(#DUTF, _RHO) _])) => #DUTF(V) ... </k>
 
   rule <k> #DUTF((con bytestring B:ByteString)) =>
-           (con string #decodeUtf8(B)) </k>
+           (con string #decodeUtf8(B)) ... </k>
 ```
 
 ## `appendString`
@@ -44,7 +44,7 @@ module UPLC-STRING-BUILTINS
   rule <k> (V2:Value ~> ([ Clos(#ASTR(V1:Value), _RHO) _])) => #ASTR(V1, V2) ... </k>
 
   rule <k> #ASTR((con string S1:String), (con string S2:String)) =>
-           (con string #appendString(S1, S2)) </k>
+           (con string #appendString(S1, S2)) ... </k>
 ```
 
 ## `equalsString`
@@ -56,13 +56,10 @@ module UPLC-STRING-BUILTINS
 
   rule <k> (V2:Value ~> ([ Clos(#ESTR(V1:Value), _RHO) _])) => #ESTR(V1, V2) ... </k>
 
-  rule <k> #ESTR((con string S1:String), (con string S2:String)) =>
-           (con bool
-            #if #equalsString(S1, S2)
-            #then (True)
-            #else (False)
-            #fi)
-       </k>  
+  rule <k> #ESTR((con string S1:String), (con string S2:String)) => (con bool True) ... </k>
+  requires #equalsString(S1, S2)
+
+  rule <k> #ESTR(_,_) => (con bool False) ... </k> [owise]
 ```
 
 ```k


### PR DESCRIPTION
- Recursive functions using #if#then#else#fi may loop when compiled to the haskell backend. Polymorphic K conditional was replaced by rules to work around this problem. (I use #if#then#else#fi to avoid conditional rules.) 

- Some of the rules were missing ellipsis (...) in k cells. This PR also fixes it. 