### PR TITLE
Update Flat Parser Using BitStream Sort

### DIFF
--- a/bitstream.md
+++ b/bitstream.md
@@ -1,0 +1,49 @@
+# BitStreams
+
+This module defines a `BitStream` sort. This sort can be used to get arbitrary numbers of bits from
+a `Bytes` sort. This use an integer that represents the current position to "traverse" the `Bytes`.
+This allows users to operate on this sort without having to keep track of the current position.
+However, they are expected to update this number after using operations such as #readNBits.
+
+```k
+module BITSTREAM
+  imports BYTES
+  imports INT
+
+  syntax BitStream ::= BitStream(Int, Bytes)
+
+  syntax Bytes ::= getBitStreamBytes(BitStream) [function]
+//=========================================================
+  rule getBitStreamBytes( BitStream(_, Bs) ) => Bs
+
+  syntax Int ::= getBitStreamPos(BitStream) [function]
+//=========================================================
+  rule getBitStreamPos( BitStream(I, _) ) => I
+
+
+  syntax Int ::= indexBitStream (Int, BitStream) [function]
+//=========================================================
+  rule indexBitStream(I, Bs) => (getBitStreamBytes(Bs)[I divInt 8] >>Int (7 -Int (I modInt 8))) &Int 1 
+
+
+  syntax Int ::= getNextBit(BitStream) [function]
+//===============================================
+  rule getNextBit(Bs) => indexBitStream(getBitStreamPos(Bs), Bs)
+
+  syntax BitStream ::= advancePos(BitStream) [function]
+//=====================================================
+  rule advancePos(Bs) => BitStream(getBitStreamPos(Bs) +Int 1, getBitStreamBytes(Bs))
+
+
+  syntax Int ::= #readNBits(Int, BitStream) [function]
+//==================================================
+  rule #readNBits(0,  _) => 0
+  rule #readNBits(N, Bs) => (getNextBit(Bs) <<Int N -Int 1) |Int #readNBits(N -Int 1, advancePos(Bs)) [owise]
+
+
+  syntax Int ::= #nextByteBoundary(Int) [function]
+//------------------------------------------------
+  rule #nextByteBoundary(I) => I +Int ( 8 -Int ( I modInt 8 ) )
+
+endmodule
+```

--- a/bitstream.md
+++ b/bitstream.md
@@ -13,30 +13,30 @@ module BITSTREAM
   syntax BitStream ::= BitStream(Int, Bytes)
 
   syntax Bytes ::= getBitStreamBytes(BitStream) [function]
-//=========================================================
+//--------------------------------------------------------
   rule getBitStreamBytes( BitStream(_, Bs) ) => Bs
 
   syntax Int ::= getBitStreamPos(BitStream) [function]
-//=========================================================
+//----------------------------------------------------
   rule getBitStreamPos( BitStream(I, _) ) => I
 
 
   syntax Int ::= indexBitStream (Int, BitStream) [function]
-//=========================================================
+//---------------------------------------------------------
   rule indexBitStream(I, Bs) => (getBitStreamBytes(Bs)[I divInt 8] >>Int (7 -Int (I modInt 8))) &Int 1 
 
 
   syntax Int ::= getNextBit(BitStream) [function]
-//===============================================
+//-----------------------------------------------
   rule getNextBit(Bs) => indexBitStream(getBitStreamPos(Bs), Bs)
 
   syntax BitStream ::= advancePos(BitStream) [function]
-//=====================================================
+//-----------------------------------------------------
   rule advancePos(Bs) => BitStream(getBitStreamPos(Bs) +Int 1, getBitStreamBytes(Bs))
 
 
   syntax Int ::= #readNBits(Int, BitStream) [function]
-//==================================================
+//----------------------------------------------------
   rule #readNBits(0,  _) => 0
   rule #readNBits(N, Bs) => (getNextBit(Bs) <<Int N -Int 1) |Int #readNBits(N -Int 1, advancePos(Bs)) [owise]
 

--- a/tests/flat/false.flat.expected
+++ b/tests/flat/false.flat.expected
@@ -1,6 +1,6 @@
 <generatedTop>
   <k>
-    b"0100004a01" ~> .
+    ( con bool False ) ~> .
   </k>
   <env>
     .Map

--- a/tests/flat/true.flat.expected
+++ b/tests/flat/true.flat.expected
@@ -1,6 +1,6 @@
 <generatedTop>
   <k>
-    b"0100004a21" ~> .
+    ( con bool True ) ~> .
   </k>
   <env>
     .Map

--- a/tests/flat/unitval.flat.expected
+++ b/tests/flat/unitval.flat.expected
@@ -1,6 +1,6 @@
 <generatedTop>
   <k>
-    b"0100004981" ~> .
+    ( con unit () ) ~> .
   </k>
   <env>
     .Map

--- a/uplc-configuration.md
+++ b/uplc-configuration.md
@@ -4,8 +4,11 @@
 require "domains.md"
 require "uplc-syntax.md"
 require "uplc-environment.md"
+require "uplc-flat-parser.md"
 
 module UPLC-CONFIGURATION
+  imports UPLC-SYNTAX
+  imports UPLC-FLAT-PARSER
   imports INT
   imports MAP
   imports LIST
@@ -27,10 +30,13 @@ is used to keep track of the data emitted by the `trace` builtin.
 ```k 
 
   syntax Program ::= #handleProgram(Program) [function]
-                   | Bytes
 
   rule #handleProgram(C:ConcreteProgram) => C
-  rule #handleProgram(F:FlatProgram) => String2Bytes(trimByteString({F}:>ByteString))
+  rule #handleProgram(F:FlatProgram) => #bytes2program(getBytes(F))
+
+  syntax Bytes ::= getBytes(FlatProgram) [function]
+  rule getBytes(F) => Int2Bytes(String2Base(trimByteString({F}:>ByteString),16), BE, Unsigned)
+
 
   configuration <k> #handleProgram($PGM:Program) </k>
                 <env> .Env </env>

--- a/uplc-flat-parser.md
+++ b/uplc-flat-parser.md
@@ -1,0 +1,155 @@
+# Flat Parser
+
+```k
+requires "uplc-syntax.md"
+requires "bitstream.md"
+
+module UPLC-FLAT-PARSER
+  imports UPLC-SYNTAX
+  imports BYTES
+  imports BITSTREAM
+```
+
+## Flat Parser Entrypoint
+
+The following function is the entry point to the flat parser.
+
+```k
+  syntax ConcreteProgram ::= #bytes2program( Bytes )                [function]
+                           | #bytes2program( String, K, BitStream ) [function]
+
+  rule #bytes2program( BYTES ) => #bytes2program( #readVersion( BitStream( 0, BYTES ) ),
+                                                  #readTerm,
+                                                  BitStream( 24, BYTES )
+                                                )
+```
+
+The following KItems are used to manage control in the function above.
+
+```k
+  syntax KItem ::= "#readTerm"
+                 | "#readTermTag" Int
+                 | "#readValue" Int
+                 | "#readConType" Int
+```
+
+
+## Parsing The program version
+
+The program version is specified as 3 unsigned integers. This implementation only accounts for
+version numbers that are less than 7 bits and needs to be updated to parse larger integers.
+
+```k
+  syntax String ::= #readVersion(BitStream) [function]
+//----------------------------------------------------
+  rule #readVersion( BitStream( I, BYTES ) ) =>
+    Int2String( #readNBits( 8, BitStream( I, BYTES         ) ) ) +String "." +String
+    Int2String( #readNBits( 8, BitStream( I +Int 8,  BYTES ) ) ) +String "." +String
+    Int2String( #readNBits( 8, BitStream( I +Int 16, BYTES ) ) )
+```
+
+## Rules used to read Terms
+
+Note: this is a first draft and expected to change to enable parsing terms that take terms as
+parameters such as `force` and `delay`
+
+```k
+
+  rule #bytes2program( _, #readTerm => #readTermTag #readNBits( 4, BitStream( I, Bs ) ),
+                       BitStream( I => I +Int 4, Bs )
+                     )
+
+  rule #bytes2program( _, #readTermTag ERROR => ( error ),
+                       BitStream( I => #nextByteBoundary(I), _ )
+                     )
+
+  rule #bytes2program( _, #readTermTag CON => #readConType #readType( BitStream( I, Bs ) ),
+                       BitStream( I => I +Int  6, Bs )
+                     )
+
+  rule #bytes2program( _, #readConType UNIT => ( con unit () ),
+                       BitStream( I => #nextByteBoundary( I ), _ )
+                     )
+
+  rule #bytes2program( _, #readConType BOOL => ( con bool #bit2boolval( #readNBits( 1, BitStream( I, Bs ) ) ) ),
+                       BitStream( I => #nextByteBoundary( I ), Bs )
+                     )
+
+  rule #bytes2program( VERSION, TERM:Term ~> .,
+                       BitStream( X, BYTES )
+                     )
+    => ( program String2Version(VERSION) TERM )
+    requires (X /Int 8) ==Int lengthBytes(BYTES)
+
+```
+
+### Utility Functions Used to Read Terms
+
+```k
+  syntax Constant ::= #bit2boolval(Int) [function]
+//---------------------------------------------
+  rule #bit2boolval(0) => False
+  rule #bit2boolval(1) => True
+
+  // TODO: fix this function to support parametric types
+  syntax Int ::= #readType( BitStream ) [function]
+//------------------------------------------------------
+  rule #readType( BitStream( I, BYTES ) ) => #readNBits( 4, BitStream( I +Int 1, BYTES ) )
+
+  syntax Version ::= String2Version (String) [function, functional, hook(STRING.string2token)]
+```
+
+### Values used to represent Terms and Types
+
+#### Values for term tags
+
+The following `Int`s represent different terms terms and encoded using 4 bits.
+
+```k
+  syntax Int ::= "VAR"
+               | "DELAY"
+               | "LAMBDA"
+               | "APP"
+               | "CON"
+               | "FORCE"
+               | "ERROR"
+               | "BUILTIN"
+//--------------------------------
+  rule VAR     => 0 [macro]
+  rule DELAY   => 1 [macro]
+  rule LAMBDA  => 2 [macro]
+  rule APP     => 3 [macro]
+  rule CON     => 4 [macro]
+  rule FORCE   => 5 [macro]
+  rule ERROR   => 6 [macro]
+  rule BUILTIN => 7 [macro]
+```
+
+#### Values for type
+
+The following `Int`s represent types within the untypted plutus language and encoded in 4 bits.
+They are used as parameters that describe constants or as parameters to builtin functions.
+
+```k
+  syntax Int ::= "INTEGER"
+               | "BYTESTRING"
+               | "STRING"
+               | "UNIT"
+               | "BOOL"
+               | "LIST"
+               | "PAIR"
+               | "TYPE_APP"
+               | "DATA"
+//--------------------------------
+  rule INTEGER    => 0 [macro]
+  rule BYTESTRING => 1 [macro]
+  rule STRING     => 2 [macro]
+  rule UNIT       => 3 [macro]
+  rule BOOL       => 4 [macro]
+  rule LIST       => 5 [macro]
+  rule PAIR       => 6 [macro]
+  rule TYPE_APP   => 7 [macro]
+  rule DATA       => 8 [macro]
+
+endmodule
+```

--- a/uplc-flat-parser.md
+++ b/uplc-flat-parser.md
@@ -87,13 +87,14 @@ parameters such as `force` and `delay`
 
 ```k
   syntax Constant ::= #bit2boolval(Int) [function]
-//---------------------------------------------
+//------------------------------------------------
   rule #bit2boolval(0) => False
   rule #bit2boolval(1) => True
 
   // TODO: fix this function to support parametric types
+
   syntax Int ::= #readType( BitStream ) [function]
-//------------------------------------------------------
+//------------------------------------------------
   rule #readType( BitStream( I, BYTES ) ) => #readNBits( 4, BitStream( I +Int 1, BYTES ) )
 
   syntax Version ::= String2Version (String) [function, functional, hook(STRING.string2token)]
@@ -114,7 +115,7 @@ The following `Int`s represent different terms terms and encoded using 4 bits.
                | "FORCE"
                | "ERROR"
                | "BUILTIN"
-//--------------------------------
+//------------------------
   rule VAR     => 0 [macro]
   rule DELAY   => 1 [macro]
   rule LAMBDA  => 2 [macro]
@@ -140,7 +141,7 @@ They are used as parameters that describe constants or as parameters to builtin 
                | "PAIR"
                | "TYPE_APP"
                | "DATA"
-//--------------------------------
+//---------------------------
   rule INTEGER    => 0 [macro]
   rule BYTESTRING => 1 [macro]
   rule STRING     => 2 [macro]


### PR DESCRIPTION
The previous implementation used the `Bytes` sort to implement a very limited prototype of the flat parser. This pull request implements uses a new BitStream sort to facilitate parsing the flat format. This is an initial attempt that parses the existing flat tests properly. More to come later.