### PR TITLE
update flat format tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,7 @@ pipeline {
             stage('uplc-examples')                 { steps { sh 'make test-uplc-examples -j4 --output-sync=recurse'                 } }
             stage('benchmark-validation-examples') { steps { sh 'make test-benchmark-validation-examples -j4 --output-sync=recurse' } }
             stage('nofib-exe-examples')            { steps { sh 'make test-nofib-exe-examples -j4 --output-sync=recurse'            } }
+            stage('flat')                          { steps { sh 'make test-flat -j4 --output-sync=recurse'                          } }
           }
         }
         stage('Test Interactive') {

--- a/Makefile
+++ b/Makefile
@@ -355,15 +355,25 @@ tests/%.uplc.run: tests/%.uplc
 	[ ! -f $<$(EXPECTED2) ] $(CONTINUE) $(TEST2) $< $(TEST_OPTIONS2) > $<.out
 	[ ! -f $<$(EXPECTED2) ] $(CONTINUE) $(CHECK) $<.out $<$(EXPECTED2)
 
+TEST_FLAT          := $(KPLUTUS) run
+TEST_FLAT2         := $(KPLUTUS) run
+TEST_FLAT_OPTIONS  := --flat-format $(TEST_OPTIONS)
+TEST_FLAT_OPTIONS2 := --flat-format
+
 tests/%.flat.run: tests/%.flat
-	$(TEST) $< --flat-format > $<.out
+	@echo $(BWhite)$(TEST_MSG)$(Color_off)$(Green)$<$(Color_Off)"\n"
+	$(TEST_FLAT) $< $(TEST_FLAT_OPTIONS) > $<.out
 	$(CHECK) $<.out $<$(EXPECTED)
+	$(TEST_FLAT2) $< $(TEST_FLAT_OPTIONS2) > $<.out
+	$(CHECK) $<.out $<$(EXPECTED2)
 
 update-results: conformance-test
 update-results: TEST=$(UPLC) evaluate --print-mode Classic -i
+update-results: TEST_FLAT=$(UPLC) evaluate --if flat --print-mode Classic -i
 # The trail command below removes break lines that litters
 # the .EXPECTED file and breaks testing.
 update-results: TEST_OPTIONS= | tr -d '\012\015'
+update-results: TEST_FLAT_OPTIONS= | tr -d '\012\015'
 update-results: CHECK=cp
 update-results: TEST_MSG="\n>>> Updating results for "
 update-results: CONTINUE=;
@@ -382,7 +392,8 @@ update-results: CONTINUE=;
 conformance-test: test-simple                        \
                   test-uplc-examples                 \
                   test-benchmark-validation-examples \
-                  test-nofib-exe-examples
+                  test-nofib-exe-examples            \
+                  test-flat
 
 # Simple Tests
 

--- a/tests/flat/false.flat.expected
+++ b/tests/flat/false.flat.expected
@@ -1,11 +1,1 @@
-<generatedTop>
-  <k>
-    ( con bool False ) ~> .
-  </k>
-  <env>
-    .Map
-  </env>
-  <trace>
-    .List
-  </trace>
-</generatedTop>
+(con bool False)

--- a/tests/flat/false.flat.krun.expected
+++ b/tests/flat/false.flat.krun.expected
@@ -1,0 +1,11 @@
+<generatedTop>
+  <k>
+    < con bool False > ~> .
+  </k>
+  <env>
+    .Env
+  </env>
+  <trace>
+    .List
+  </trace>
+</generatedTop>

--- a/tests/flat/true.flat.expected
+++ b/tests/flat/true.flat.expected
@@ -1,11 +1,1 @@
-<generatedTop>
-  <k>
-    ( con bool True ) ~> .
-  </k>
-  <env>
-    .Map
-  </env>
-  <trace>
-    .List
-  </trace>
-</generatedTop>
+(con bool True)

--- a/tests/flat/true.flat.krun.expected
+++ b/tests/flat/true.flat.krun.expected
@@ -1,0 +1,11 @@
+<generatedTop>
+  <k>
+    < con bool True > ~> .
+  </k>
+  <env>
+    .Env
+  </env>
+  <trace>
+    .List
+  </trace>
+</generatedTop>

--- a/tests/flat/unitval.flat.expected
+++ b/tests/flat/unitval.flat.expected
@@ -1,11 +1,1 @@
-<generatedTop>
-  <k>
-    ( con unit () ) ~> .
-  </k>
-  <env>
-    .Map
-  </env>
-  <trace>
-    .List
-  </trace>
-</generatedTop>
+(con unit ())

--- a/tests/flat/unitval.flat.krun.expected
+++ b/tests/flat/unitval.flat.krun.expected
@@ -1,0 +1,11 @@
+<generatedTop>
+  <k>
+    < con unit () > ~> .
+  </k>
+  <env>
+    .Env
+  </env>
+  <trace>
+    .List
+  </trace>
+</generatedTop>


### PR DESCRIPTION
This pull request contains changes that updates the flat format tests and expected outputs. `make test-flat` now compares output between `uplc` and `kplc` (similar to `test-simple`).