### PR TITLE
Fix variable identifier syntax

### DIFF
--- a/tests/failing
+++ b/tests/failing
@@ -20,14 +20,10 @@ tests/simple/ifThenElse-no-force.uplc
 #
 # UPLC examples 
 #
-# Factorial has an identifier with `'` that K does not parse
+# Factorial output does not match uplc's output due to unknown reason. Needs investigation
 tests/uplc-examples/factorial.uplc
 # The source of failure here is not identified yet: 3/16/22, CBraga
 tests/uplc-examples/IfIntegers.uplc
-# Factorial has an identifier with `'` that K does not parse
-tests/uplc-examples/NatRoundTrip.uplc
-# ScottListSum has an identifier with `'` that K does not parse
-tests/uplc-examples/ScottListSum.uplc
 # DivideByZero returns an error. We need to adapt our test harness to
 # error handling.
 tests/uplc-examples/DivideByZero.uplc

--- a/tests/uplc-examples/NatRoundTrip.uplc.expected
+++ b/tests/uplc-examples/NatRoundTrip.uplc.expected
@@ -1,0 +1,1 @@
+(con integer 1)

--- a/tests/uplc-examples/NatRoundTrip.uplc.krun.expected
+++ b/tests/uplc-examples/NatRoundTrip.uplc.krun.expected
@@ -1,0 +1,11 @@
+<generatedTop>
+  <k>
+    < con integer 1 > ~> .
+  </k>
+  <env>
+    bind ( f , < lam n' [ [ rec [ f z  .TermList ]  .TermList ] n'  .TermList ] bind ( n , < delay ( lam z ( lam f z ) ) .Env > )  bind ( z , < con integer 1 > )  bind ( rec , < lam x [ [ f [ ( force ( delay ( lam s [ s s  .TermList ] ) ) ) s  .TermList ]  .TermList ] x  .TermList ] bind ( s , < lam s ( lam x [ [ f [ ( force ( delay ( lam s [ s s  .TermList ] ) ) ) s  .TermList ]  .TermList ] x  .TermList ] ) bind ( f , < lam rec ( lam z ( lam n [ [ ( force n ) z  .TermList ] ( lam n' [ [ rec [ f z  .TermList ]  .TermList ] n'  .TermList ] )  .TermList ] ) ) bind ( f , < builtin addInteger ListItem ( < con integer 1 > ) 1 > )  .Env > )  bind ( f , < builtin addInteger ListItem ( < con integer 1 > ) 1 > )  .Env > )  bind ( f , < lam rec ( lam z ( lam n [ [ ( force n ) z  .TermList ] ( lam n' [ [ rec [ f z  .TermList ]  .TermList ] n'  .TermList ] )  .TermList ] ) ) bind ( f , < builtin addInteger ListItem ( < con integer 1 > ) 1 > )  .Env > )  bind ( f , < builtin addInteger ListItem ( < con integer 1 > ) 1 > )  .Env > )  bind ( f , < builtin addInteger ListItem ( < con integer 1 > ) 1 > )  .Env > )  bind ( z , < con integer 1 > )  .Env
+  </env>
+  <trace>
+    .List
+  </trace>
+</generatedTop>

--- a/tests/uplc-examples/ScottListSum.uplc.expected
+++ b/tests/uplc-examples/ScottListSum.uplc.expected
@@ -1,0 +1,1 @@
+(con integer 0)

--- a/tests/uplc-examples/ScottListSum.uplc.krun.expected
+++ b/tests/uplc-examples/ScottListSum.uplc.krun.expected
@@ -1,0 +1,11 @@
+<generatedTop>
+  <k>
+    < con integer 0 > ~> .
+  </k>
+  <env>
+    bind ( f , < lam x ( lam xs' [ [ rec [ [ f z  .TermList ] x  .TermList ]  .TermList ] xs'  .TermList ] ) bind ( xs , < delay ( lam z ( lam f z ) ) .Env > )  bind ( z , < con integer 0 > )  bind ( rec , < lam x [ [ f [ ( force ( delay ( lam s [ s s  .TermList ] ) ) ) s  .TermList ]  .TermList ] x  .TermList ] bind ( s , < lam s ( lam x [ [ f [ ( force ( delay ( lam s [ s s  .TermList ] ) ) ) s  .TermList ]  .TermList ] x  .TermList ] ) bind ( f , < lam rec ( lam z ( lam xs [ [ ( force xs ) z  .TermList ] ( lam x ( lam xs' [ [ rec [ [ f z  .TermList ] x  .TermList ]  .TermList ] xs'  .TermList ] ) )  .TermList ] ) ) bind ( f , < builtin addInteger .List 2 > )  .Env > )  bind ( f , < builtin addInteger .List 2 > )  .Env > )  bind ( f , < lam rec ( lam z ( lam xs [ [ ( force xs ) z  .TermList ] ( lam x ( lam xs' [ [ rec [ [ f z  .TermList ] x  .TermList ]  .TermList ] xs'  .TermList ] ) )  .TermList ] ) ) bind ( f , < builtin addInteger .List 2 > )  .Env > )  bind ( f , < builtin addInteger .List 2 > )  .Env > )  bind ( f , < builtin addInteger .List 2 > )  .Env > )  bind ( z , < con integer 0 > )  .Env
+  </env>
+  <trace>
+    .List
+  </trace>
+</generatedTop>

--- a/uplc-environment.md
+++ b/uplc-environment.md
@@ -2,25 +2,26 @@
 
 ```k
 require "domains.md"
+require "uplc-syntax.md"
 
 module UPLC-ENVIRONMENT
-  imports ID
+  imports UPLC-ID
   imports BOOL
   imports K-EQUAL
 
   syntax Bindable
-  syntax Bind ::= bind(Id, Bindable)
+  syntax Bind ::= bind(UplcId, Bindable)
   syntax Env ::= List{Bind,""} 
 
-  syntax Bool ::= #in(Env, Id) [function]
+  syntax Bool ::= #in(Env, UplcId) [function]
   rule #in(.Env, _) => false 
-  rule #in(bind(X:Id, _) _, X) => true
-  rule #in(bind(Y:Id, _) E:Env, X:Id) => #in(E, X)
+  rule #in(bind(X:UplcId, _) _, X) => true
+  rule #in(bind(Y:UplcId, _) E:Env, X:UplcId) => #in(E, X)
   requires X =/=K Y
   
-  syntax Bindable ::= #lookup(Env, Id) [function]
-  rule #lookup(bind(X:Id, V:Bindable) _, X:Id) => V
-  rule #lookup(bind(X:Id, _) E:Env, Y:Id) => #lookup(E, Y)
+  syntax Bindable ::= #lookup(Env, UplcId) [function]
+  rule #lookup(bind(X:UplcId, V:Bindable) _, X:UplcId) => V
+  rule #lookup(bind(X:UplcId, _) E:Env, Y:UplcId) => #lookup(E, Y)
   requires X =/=K Y
 
   syntax Env ::= #push(Env, Bind) [function]

--- a/uplc-semantics.md
+++ b/uplc-semantics.md
@@ -28,13 +28,13 @@ module UPLC-SEMANTICS
 ```k
   rule <k> (program _V M) => M </k>
 
-  rule <k> X:Id => #lookup(RHO, X) ... </k>
+  rule <k> X:UplcId => #lookup(RHO, X) ... </k>
        <env> RHO </env>
 
   rule <k> (con T:TypeConstant C:Constant) =>
            < con T:TypeConstant C:Constant > ... </k>
 
-  rule <k> (lam X:Id M:Term) => < lam X M RHO > ... </k>
+  rule <k> (lam X:UplcId M:Term) => < lam X M RHO > ... </k>
        <env> RHO:Env </env>
 
   rule <k> (delay M:Term) => < delay M RHO > ... </k>
@@ -48,7 +48,7 @@ module UPLC-SEMANTICS
   rule <k> V:Value ~> [_ M RHO:Env ] => M ~> [ V _] ... </k>
        <env> _ => RHO </env>
 
-  rule <k> V:Value ~> [ < lam X:Id M:Term RHO:Env > _] => M ... </k>
+  rule <k> V:Value ~> [ < lam X:UplcId M:Term RHO:Env > _] => M ... </k>
        <env> _ => #push(RHO, bind(X, V)) </env>
 
   rule <k> < delay M:Term RHO:Env > ~> Force => M ... </k>

--- a/uplc-syntax.md
+++ b/uplc-syntax.md
@@ -5,13 +5,19 @@ require "domains.md"
 require "uplc-bytestring.md"
 require "uplc-environment.md"
 
+module UPLC-ID
+
+  syntax UplcId ::= r"[A-Za-z][A-Za-z0-9\\_\\']*" [prec(1), token]
+
+endmodule
+
 module UPLC-SYNTAX
-  imports ID
   imports LIST
   imports STRING
   imports INT-SYNTAX
   imports UPLC-BYTESTRING
   imports UPLC-ENVIRONMENT
+  imports UPLC-ID
 
   syntax Program ::= ConcreteProgram
                    | FlatProgram
@@ -22,17 +28,17 @@ module UPLC-SYNTAX
 
   syntax Version ::= r"[0-9]+.[0-9]+.[0-9]+" [token]
 
-  syntax Term ::= Id
+  syntax Term ::= UplcId
                 | "(" "con" TypeConstant Constant ")"
                 | "(" "builtin" BuiltinName ")"
-                | "(" "lam" Id Term ")"
+                | "(" "lam" UplcId Term ")"
                 | "[" Term TermList "]"
                 | "(" "delay" Term ")"
                 | "(" "force" Term ")"
                 | "(" "error" ")"
 
   syntax Value ::= "<" "con" TypeConstant Constant ">"
-                 | "<" "lam" Id Term Env ">"
+                 | "<" "lam" UplcId Term Env ">"
                  | "<" "delay" Term Env ">"
                  | "<" "builtin" BuiltinName List Int ">"
 


### PR DESCRIPTION
This pull request fixes the syntax for uplc variables. Uplc variables allow a `'` which is disallowed by the `Id` sort found in `domains.md`. Fix the identifier syntax so it matches the spec and remove a few tests from `tests/failing`.