### PR TITLE
Fixed a bug on builtin evaluation.

### DIFF
--- a/tests/failing
+++ b/tests/failing
@@ -5,9 +5,6 @@
 # state which appears should be understood as the error behavior in
 # uplc
 tests/simple/error.uplc
-# Builtin ifThenElse needs a force to work in uplc but it does not
-# work (with force) in KPlutus.
-tests/simple/ifThenElse.uplc
 # Delay uses a free-variable therefore it fails.
 tests/simple/delay.uplc
 # Force uses a free-varaible therefore it fails.
@@ -20,10 +17,6 @@ tests/simple/ifThenElse-no-force.uplc
 #
 # UPLC examples 
 #
-# Factorial output does not match uplc's output due to unknown reason. Needs investigation
-tests/uplc-examples/factorial.uplc
-# The source of failure here is not identified yet: 3/16/22, CBraga
-tests/uplc-examples/IfIntegers.uplc
 # DivideByZero returns an error. We need to adapt our test harness to
 # error handling.
 tests/uplc-examples/DivideByZero.uplc

--- a/uplc-bytestring-builtins.md
+++ b/uplc-bytestring-builtins.md
@@ -16,10 +16,12 @@ module UPLC-BYTESTRING-BUILTINS
 ```k
   rule <k> (builtin appendByteString) => < builtin appendByteString .List 2 > ... </k>
 
-  rule <k> < builtin appendByteString
+  rule <k> #eval(appendByteString,
                      (ListItem(< con bytestring B1:ByteString >)
-                      ListItem(< con bytestring B2:ByteString >)) 0 > =>
+                      ListItem(< con bytestring B2:ByteString >))) =>
            < con bytestring #appendByteString(B1, B2) > ... </k>
+
+  rule <k> #eval(appendByteString, _) => (error) ... </k> [owise]
 ```
 
 ## `consByteString`
@@ -27,10 +29,12 @@ module UPLC-BYTESTRING-BUILTINS
 ```k
   rule <k> (builtin consByteString) => < builtin consByteString .List 2 > ... </k>
 
-  rule <k> < builtin consByteString
+  rule <k> #eval(consByteString,
                      (ListItem(< con integer I:Int >)
-                      ListItem(< con bytestring B:ByteString >)) 0 > =>
+                      ListItem(< con bytestring B:ByteString >))) =>
            < con bytestring #consByteString(I, B) > ... </k>
+
+  rule <k> #eval(consByteString, _) => (error) ... </k> [owise]
 ```
 
 ## `sliceByteString`
@@ -38,11 +42,13 @@ module UPLC-BYTESTRING-BUILTINS
 ```k
   rule <k> (builtin sliceByteString) => < builtin sliceByteString .List 3 > ... </k>
 
-  rule <k> <builtin sliceByteString
+  rule <k> #eval(sliceByteString,
                     (ListItem(< con integer I1:Int >)
                      ListItem(< con integer I2:Int >)
-                     ListItem(< con bytestring B:ByteString >)) 0 > =>
+                     ListItem(< con bytestring B:ByteString >))) =>
            < con bytestring #sliceByteString(I1, I2, B) > ... </k>
+
+  rule <k> #eval(sliceByteString, _) => (error) ... </k> [owise] 
 ```
 
 ## `lengthOfByteString`
@@ -50,9 +56,11 @@ module UPLC-BYTESTRING-BUILTINS
 ```k
   rule <k> (builtin lengthOfByteString) => < builtin lengthOfByteString .List 1 > ... </k>
 
-  rule <k> < builtin lengthOfByteString
-                     ListItem(< con bytestring B:ByteString >) 0 > =>
+  rule <k> #eval(lengthOfByteString,
+                     ListItem(< con bytestring B:ByteString >)) =>
            < con integer #lengthOfByteString(B) > ... </k>
+
+  rule <k> #eval(lengthOfByteString, _) => (error) ... </k> [owise]
 ```
 
 ## `indexByteString`
@@ -60,10 +68,13 @@ module UPLC-BYTESTRING-BUILTINS
 ```k
   rule <k> (builtin indexByteString) => < builtin indexByteString .List 2 > ... </k>
 
-  rule <k> < builtin indexByteString
+  rule <k> #eval(indexByteString,
                      (ListItem(< con bytestring B:ByteString >)
-                      ListItem(< con integer I:Int >)) 0 > =>
+                      ListItem(< con integer I:Int >))) =>
            < con integer #indexByteString(B, I) > ... </k>
+
+  rule <k> #eval(indexByteString, _) => (error) ... </k> [owise]
+
 ```
 
 ## `equalsByteString`
@@ -71,15 +82,19 @@ module UPLC-BYTESTRING-BUILTINS
 ```k
   rule <k> (builtin equalsByteString) => < builtin equalsByteString .List 2 > ... </k>
 
-  rule <k> < builtin equalsByteString
+  rule <k> #eval(equalsByteString,
                      (ListItem(< con bytestring B1:ByteString >)
-                      ListItem(< con bytestring B2:ByteString >)) 0 > =>
+                      ListItem(< con bytestring B2:ByteString >))) =>
            < con bool True > ... </k>
   requires #equalsByteString(B1, B2)
 
-  rule <k> < builtin equalsByteString _ 0 > =>
-           < con bool False > ... </k> [owise]
+  rule <k> #eval(equalsByteString,
+                     (ListItem(< con bytestring B1:ByteString >)
+                      ListItem(< con bytestring B2:ByteString >))) =>
+           < con bool False > ... </k>
+  requires notBool #equalsByteString(B1, B2)
 
+  rule <k> #eval(equalsByteString, _) => (error) ... </k> [owise]
 ```
 
 ## `lessThanByteString`
@@ -87,13 +102,19 @@ module UPLC-BYTESTRING-BUILTINS
 ```k
   rule <k> (builtin lessThanByteString) => < builtin lessThanByteString .List 2 > ... </k>
 
-  rule <k> < builtin lessThanByteString
+  rule <k> #eval(lessThanByteString,
                      (ListItem(< con bytestring B1:ByteString >)
-                      ListItem(< con bytestring B2:ByteString >)) 0 > =>
+                      ListItem(< con bytestring B2:ByteString >))) =>
            < con bool True > ... </k>
   requires #lessThanByteString(B1, B2)
 
-  rule <k> < builtin lessThanByteString _ 0 > => < con bool False > ... </k> [owise]
+  rule <k> #eval(lessThanByteString,
+                     (ListItem(< con bytestring B1:ByteString >)
+                      ListItem(< con bytestring B2:ByteString >))) =>
+           < con bool False > ... </k>
+  requires notBool #lessThanByteString(B1, B2)
+
+  rule <k> #eval(lessThanByteString, _) => (error) ... </k> [owise]
 ```
 
 ## `lessThanEqualsByteString`
@@ -102,14 +123,19 @@ module UPLC-BYTESTRING-BUILTINS
   rule <k> (builtin lessThanEqualsByteString) =>
             < builtin lessThanEqualsByteString .List 2 > ... </k>
 
-  rule <k> < builtin lessThanEqualsByteString
+  rule <k> #eval(lessThanEqualsByteString,
                      (ListItem(< con bytestring B1:ByteString >)
-                      ListItem(< con bytestring B2:ByteString >)) 0 > =>
+                      ListItem(< con bytestring B2:ByteString >))) =>
            < con bool True > ... </k>
   requires #lessThanEqualsByteString(B1, B2)
 
-  rule <k> < builtin lessThanEqualsByteString _ 0 > =>
-           < con bool False > ... </k> [owise]
+  rule <k> #eval(lessThanEqualsByteString,
+                     (ListItem(< con bytestring B1:ByteString >)
+                      ListItem(< con bytestring B2:ByteString >))) =>
+           < con bool False > ... </k>
+  requires notBool #lessThanEqualsByteString(B1, B2)
+
+  rule <k> #eval(lessThanEqualsByteString, _) => (error) ... </k> [owise]
 ```
 
 ```k

--- a/uplc-configuration.md
+++ b/uplc-configuration.md
@@ -28,6 +28,7 @@ and values) is for its environment, and `<trace>` (a list of strings)
 is used to keep track of the data emitted by the `trace` builtin.
 
 ```k 
+  syntax Value ::= #eval(BuiltinName, List) 
 
   syntax Program ::= #handleProgram(Program) [function]
 
@@ -36,7 +37,6 @@ is used to keep track of the data emitted by the `trace` builtin.
 
   syntax Bytes ::= getBytes(FlatProgram) [function]
   rule getBytes(F) => Int2Bytes(String2Base(trimByteString({F}:>ByteString),16), BE, Unsigned)
-
 
   configuration <k> #handleProgram($PGM:Program) </k>
                 <env> .Env </env>

--- a/uplc-crypto-builtins.md
+++ b/uplc-crypto-builtins.md
@@ -41,8 +41,11 @@ a ByteString.
 ```k 
   rule <k> (builtin sha3_256) => < builtin sha3_256 .List 1 >  ... </k>
 
-  rule <k> < builtin sha3_256 ListItem(< con bytestring B:ByteString >) 0 > =>
+  rule <k> #eval(sha3_256, ListItem(< con bytestring B:ByteString >)) =>
            < con bytestring unTrimByteString(Sha3_256(encode(B))) > ... </k>
+
+  rule <k> #eval(sha3_256, _) => (error) ... </k> [owise]
+
 ```
 
 ## `sha2_256`
@@ -52,8 +55,10 @@ The same steps of `sha3_256` are taken to produce the proper string argument for
 ```k 
   rule <k> (builtin sha2_256) => < builtin sha2_256 .List 1 >  ... </k>
 
-  rule <k> < builtin sha2_256 ListItem(< con bytestring B:ByteString >) 0 > =>
+  rule <k> #eval(sha2_256, ListItem(< con bytestring B:ByteString >)) =>
            < con bytestring unTrimByteString(Sha256(encode(B))) > ... </k>
+
+  rule <k> #eval(sha2_256, _) => (error) ... </k> [owise]
 ```
 
 ## `blake2b_256`
@@ -63,8 +68,10 @@ The same steps of `sha3_256` are taken to produce the proper string argument for
 ```k
   rule <k> (builtin blake2b_256) => < builtin blake2b_256 .List 1 > ... </k>
 
-  rule <k> < builtin blake2b_256 ListItem(< con bytestring B:ByteString >) 0 > =>
+  rule <k> #eval(blake2b_256, ListItem(< con bytestring B:ByteString >)) =>
            < con bytestring unTrimByteString(Blake2b256(encode(B))) > ... </k>
+
+  rule <k> #eval(blake2b_256, _) => (error) ... </k> [owise]
 ```
 
 ## `verifySignature`
@@ -72,14 +79,21 @@ The same steps of `sha3_256` are taken to produce the proper string argument for
 ```k
   rule <k> (builtin verifySignature) => < builtin verifySignature .List 3 > ... </k>
 
-  rule <k> < builtin verifySignature
+  rule <k> #eval(verifySignature,
                  (ListItem(< con bytestring K:ByteString >)
                   ListItem(< con bytestring M:ByteString >)
-                  ListItem(< con bytestring S:ByteString >)) 0 > =>
+                  ListItem(< con bytestring S:ByteString >))) =>
            < con bool True > ... </k>
   requires ED25519VerifyMessage(encode(K), encode(M), encode(S))
 
-  rule <k> < builtin verifySignature _ 0 > => < con bool False > ... </k> [owise]
+  rule <k> #eval(verifySignature,
+                 (ListItem(< con bytestring K:ByteString >)
+                  ListItem(< con bytestring M:ByteString >)
+                  ListItem(< con bytestring S:ByteString >))) =>
+           < con bool False > ... </k>
+  requires notBool ED25519VerifyMessage(encode(K), encode(M), encode(S))
+
+  rule <k> #eval(verifySignature, _) => (error) ... </k> [owise]
 ```
 
 ```k

--- a/uplc-integer-builtins.md
+++ b/uplc-integer-builtins.md
@@ -13,10 +13,12 @@ module UPLC-INTEGER-BUILTINS
 ```k
   rule <k> (builtin addInteger) => < builtin addInteger .List 2 > ... </k>
 
-  rule <k> < builtin addInteger
+  rule <k> #eval(addInteger,
                      (ListItem(< con integer I1:Int >)
-                      ListItem(< con integer I2:Int >)) 0 > =>
+                      ListItem(< con integer I2:Int >))) =>
            < con integer I1 +Int I2 > ... </k>
+
+  rule <k> #eval(addInteger, _) => (error) ... </k> [owise]
 ```
 
 ## `multiplyInteger`
@@ -24,10 +26,12 @@ module UPLC-INTEGER-BUILTINS
 ```k
   rule <k> (builtin multiplyInteger) => < builtin multiplyInteger .List 2 > ... </k>
 
-  rule <k> < builtin multiplyInteger
+  rule <k> #eval(multiplyInteger,
                      (ListItem(< con integer I1:Int >)
-                      ListItem(< con integer I2:Int >)) 0 > =>
+                      ListItem(< con integer I2:Int >))) =>
            < con integer I1 *Int I2 > ... </k>
+
+  rule <k> #eval(multiplyInteger, _) => (error) ... </k> [owise]
 ```
 
 ## `subtractInteger`
@@ -35,10 +39,12 @@ module UPLC-INTEGER-BUILTINS
 ```k
   rule <k> (builtin subtractInteger) => < builtin subtractInteger .List 2 > ... </k>
 
-  rule <k> < builtin subtractInteger
+  rule <k> #eval(subtractInteger,
                      (ListItem(< con integer I1:Int >)
-                      ListItem(< con integer I2:Int >)) 0 > =>
+                      ListItem(< con integer I2:Int >))) =>
            < con integer I1 -Int I2 > ... </k>
+
+  rule <k> #eval(subtractInteger, _) => (error) ... </k> [owise]
 ```
 
 ## `divideInteger`
@@ -49,13 +55,13 @@ mathematical integer division operation.
 ```k
   rule <k> (builtin divideInteger) => < builtin divideInteger .List 2 > ... </k>
 
-  rule <k> < builtin divideInteger
+  rule <k> #eval(divideInteger,
                      (ListItem(< con integer I1:Int >)
-                      ListItem(< con integer I2:Int >)) 0 > =>
+                      ListItem(< con integer I2:Int >))) =>
            < con integer I1 /Int I2 > ... </k>
   requires I2 =/=Int 0
 
-  rule <k> < builtin divideInteger _ 0 > => (error) ... </k> [owise]
+  rule <k> #eval(divideInteger, _) => (error) ... </k> [owise]
 ```
 
 ## `modInteger`
@@ -65,13 +71,13 @@ According to Plutus specification, `modInteger` implements standard mathematical
 ```k
   rule <k> (builtin modInteger) => < builtin modInteger .List 2 > ... </k>
 
-  rule <k> < builtin modInteger
+  rule <k> #eval(modInteger,
                      (ListItem(< con integer I1:Int >)
-                      ListItem(< con integer I2:Int >)) 0 > =>
+                      ListItem(< con integer I2:Int >))) =>
            < con integer I1 modInt I2 > ... </k>
   requires I2 =/=Int 0
 
-  rule <k> < builtin modInteger _ 0 > => (error) ... </k> [owise]
+  rule <k> #eval(modInteger, _) => (error) ... </k> [owise]
 ```
 
 ## `quotientInteger`
@@ -83,13 +89,13 @@ operator `/Int`  computes the quotient using t-division which rounds towards 0.
 ```k
   rule <k> (builtin quotientInteger) => < builtin quotientInteger .List 2 > ... </k>
 
-  rule <k> < builtin quotientInteger
+  rule <k> #eval(quotientInteger,
                      (ListItem(< con integer I1:Int >)
-                      ListItem(< con integer I2:Int >)) 0 > =>
+                      ListItem(< con integer I2:Int >))) =>
            < con integer I1 /Int I2 > ... </k>
   requires I2 =/=Int 0
 
-  rule <k> < builtin quotientInteger _ 0 > => (error) ... </k> [owise]
+  rule <k> #eval(quotientInteger, _) => (error) ... </k> [owise]
 ```
 
 ## `remainderInteger`
@@ -102,13 +108,13 @@ It cooresponds to Haskell rem, according to Plutus specification. From Haskell d
 ```k
   rule <k> (builtin remainderInteger) => < builtin remainderInteger .List 2 > ... </k>
 
-  rule <k> < builtin remainderInteger
+  rule <k> #eval(remainderInteger,
                      (ListItem(< con integer I1:Int >)
-                      ListItem(< con integer I2:Int >)) 0 > =>
+                      ListItem(< con integer I2:Int >))) =>
            < con integer (I1 -Int (I1 /Int I2) *Int I2) > ... </k>
   requires I2 =/=Int 0
 
-  rule <k> < builtin remainderInteger _ 0 > => (error) ... </k> [owise]
+  rule <k> #eval(remainderInteger, _) => (error) ... </k> [owise]
 ```
 
 ## `lessThanInteger`
@@ -116,13 +122,19 @@ It cooresponds to Haskell rem, according to Plutus specification. From Haskell d
 ```k
   rule <k> (builtin lessThanInteger) => < builtin lessThanInteger .List 2 > ... </k>
 
-  rule <k> < builtin lessThanInteger
+  rule <k> #eval(lessThanInteger,
                      (ListItem(< con integer I1:Int >)
-                      ListItem(< con integer I2:Int >)) 0 > =>
+                      ListItem(< con integer I2:Int >))) =>
            < con bool True > ... </k>
   requires I1 <Int I2
 
-  rule <k> < builtin lessThanInteger _ 0 > => < con bool False > ... </k> [owise]
+  rule <k> #eval(lessThanInteger,
+                     (ListItem(< con integer I1:Int >)
+                      ListItem(< con integer I2:Int >))) =>
+           < con bool False > ... </k>
+  requires I1 >=Int I2
+
+  rule <k> #eval(lessThanInteger, _) => (error) ... </k> [owise]
 ```
 
 ## `lessThanEqualsInteger`
@@ -131,13 +143,19 @@ It cooresponds to Haskell rem, according to Plutus specification. From Haskell d
   rule <k> (builtin lessThanEqualsInteger) =>
            < builtin lessThanEqualsInteger .List 2 > ... </k>
 
-  rule <k> < builtin lessThanEqualsInteger
+  rule <k> #eval(lessThanEqualsInteger,
                      (ListItem(< con integer I1:Int >)
-                      ListItem(< con integer I2:Int >)) 0 > =>
+                      ListItem(< con integer I2:Int >))) =>
            < con bool True > ... </k>
   requires I1 <=Int I2
 
-  rule <k> < builtin lessThanEqualsInteger _ 0 > => < con bool False > ... </k> [owise]
+  rule <k> #eval(lessThanEqualsInteger,
+                     (ListItem(< con integer I1:Int >)
+                      ListItem(< con integer I2:Int >))) =>
+           < con bool False > ... </k>
+  requires I1 >Int I2
+
+  rule <k> #eval(lessThanEqualsInteger, _) => (error) ... </k> [owise]
 ```
 
 ## `equalsInteger`
@@ -146,13 +164,19 @@ It cooresponds to Haskell rem, according to Plutus specification. From Haskell d
   rule <k> (builtin equalsInteger) =>
            < builtin equalsInteger .List 2 > ... </k>
 
-  rule <k> < builtin equalsInteger
+  rule <k> #eval(equalsInteger,
                      (ListItem(< con integer I1:Int >)
-                      ListItem(< con integer I2:Int >)) 0 > =>
+                      ListItem(< con integer I2:Int >))) =>
            < con bool True > ... </k>
   requires I1 ==Int I2
 
-  rule <k> < builtin equalsInteger _ 0 > => < con bool False > ... </k> [owise]
+  rule <k> #eval(equalsInteger,
+                     (ListItem(< con integer I1:Int >)
+                      ListItem(< con integer I2:Int >))) =>
+           < con bool False > ... </k>
+  requires I1 =/=Int I2
+
+  rule <k> #eval(equalsInteger, _) => (error) ... </k> [owise]
 ```
 
 ```k

--- a/uplc-polymorphic-builtins.md
+++ b/uplc-polymorphic-builtins.md
@@ -5,6 +5,7 @@ require "uplc-configuration.md"
 
 module UPLC-POLYMORPHIC-BUILTINS
   imports UPLC-CONFIGURATION
+  imports K-EQUAL
 ```
 
 ## `ifThenElse`
@@ -12,17 +13,17 @@ module UPLC-POLYMORPHIC-BUILTINS
 ```k
   rule <k> (builtin ifThenElse) ~> Force => < builtin ifThenElse .List 3 > ... </k>
 
-  rule <k> < builtin ifThenElse
-                     (ListItem(< con bool True >)
-                      ListItem(V1:Value)
-                      ListItem(_)) 0 > => V1 ... </k>
+  rule <k> #eval(ifThenElse,
+                   (ListItem(< con bool True >)
+                    ListItem(V1:Value)
+                    ListItem(_))) => V1 ... </k>
 
-  rule <k> < builtin ifThenElse
-                     (ListItem(< con bool False >)
-                      ListItem(_)
-                      ListItem(V2:Value)) 0 > => V2 ... </k>
+  rule <k> #eval(ifThenElse,
+                   (ListItem(< con bool False >)
+                    ListItem(_)
+                    ListItem(V2:Value))) => V2 ... </k>
 
-  rule <k> < builtin ifThenElse _ 0 > => (error) ... </k> [owise]
+  rule <k> #eval(ifThenElse, _) => (error) ... </k> [owise]
 ```
 
 ## `chooseUnit`
@@ -30,9 +31,11 @@ module UPLC-POLYMORPHIC-BUILTINS
 ```k
   rule <k> (builtin chooseUnit) ~> Force => < builtin chooseUnit .List 2 > ... </k>
 
-  rule <k> < builtin chooseUnit
-                     (ListItem(< con unit () >)
-                      ListItem(V:Value)) 0 > => V ... </k>
+  rule <k> #eval(chooseUnit,
+                   (ListItem(< con unit () >)
+                    ListItem(V:Value))) => V ... </k>
+
+  rule <k> #eval(chooseUnit, _) => (error) ... </k> [owise]
 ```
 
 ## `chooseData`
@@ -40,45 +43,47 @@ module UPLC-POLYMORPHIC-BUILTINS
 ```k
   rule <k> (builtin chooseData) ~> Force => < builtin chooseData .List 6 > ... </k>
 
-  rule <k> < builtin chooseData
+  rule <k> #eval(chooseData,
                      (ListItem(< con data { Constr _Ii:Int [ _DL:DataList ] } >)
                       ListItem(C:Value)
                       ListItem(_M:Value)
                       ListItem(_L:Value)
                       ListItem(_Iv:Value)
-                      ListItem(_B:Value)) 0 > => C ... </k>
+                      ListItem(_B:Value))) => C ... </k>
 
-  rule <k> < builtin chooseData
+  rule <k> #eval(chooseData,
                      (ListItem(< con data { Map [ _DL:DataPairList ] } >)
                       ListItem(_C:Value)
                       ListItem(M:Value)
                       ListItem(_L:Value)
                       ListItem(_Iv:Value)
-                      ListItem(_B:Value)) 0 > => M ... </k>
+                      ListItem(_B:Value))) => M ... </k>
 
-  rule <k> < builtin chooseData
+  rule <k> #eval(chooseData,
                      (ListItem(< con data { List [ _DL:DataList ] } >)
                       ListItem(_C:Value)
                       ListItem(_M:Value)
                       ListItem(L:Value)
                       ListItem(_Iv:Value)
-                      ListItem(_B:Value)) 0 > => L ... </k>
+                      ListItem(_B:Value))) => L ... </k>
 
-  rule <k> < builtin chooseData
+  rule <k> #eval(chooseData,
                      (ListItem(< con data { Integer _ } >)
                       ListItem(_C:Value)
                       ListItem(_M:Value)
                       ListItem(_L:Value)
                       ListItem(I:Value)
-                      ListItem(_B:Value)) 0 > => I ... </k>
+                      ListItem(_B:Value))) => I ... </k>
 
-  rule <k> < builtin chooseData
+  rule <k> #eval(chooseData,
                      (ListItem(< con data { ByteString _ } >)
                       ListItem(_C:Value)
                       ListItem(_M:Value)
                       ListItem(_L:Value)
                       ListItem(_I:Value)
-                      ListItem(B:Value)) 0 > => B ... </k>
+                      ListItem(B:Value))) => B ... </k>
+
+  rule <k> #eval(chooseData, _) => (error) ... </k> [owise]
 ```
 
 ## `fstPair`
@@ -86,9 +91,11 @@ module UPLC-POLYMORPHIC-BUILTINS
 ```k
   rule <k> (builtin fstPair) ~> Force => < builtin fstPair .List 1 >  ... </k>
 
-  rule <k> < builtin fstPair
+  rule <k> #eval(fstPair,
               ListItem(< con pair (T1:TypeConstant) (_T2:TypeConstant)
-                         (C1:Constant, _C2:Constant) >) 0 > => < con T1 C1 > ... </k>
+                         (C1:Constant, _C2:Constant) >)) => < con T1 C1 > ... </k>
+
+  rule <k> #eval(fstPair, _) => (error) ... </k> [owise]
 ```
 
 ## `sndPair`
@@ -96,9 +103,11 @@ module UPLC-POLYMORPHIC-BUILTINS
 ```k
   rule <k> (builtin sndPair) ~> Force => < builtin sndPair .List 1 >  ... </k>
 
-  rule <k> < builtin sndPair
+  rule <k> #eval(sndPair,
               ListItem(< con pair (_T1:TypeConstant) (T2:TypeConstant)
-                         (_C1:Constant, C2:Constant) >) 0 > => < con T2 C2 > ... </k>
+                         (_C1:Constant, C2:Constant) >)) => < con T2 C2 > ... </k>
+
+  rule <k> #eval(sndPair, _) => (error) ... </k> [owise]
 ```
 
 ## `chooseList`
@@ -106,15 +115,18 @@ module UPLC-POLYMORPHIC-BUILTINS
 ```k
   rule <k> (builtin chooseList) ~> Force => < builtin chooseList .List 3 > ... </k>
 
-  rule <k> < builtin chooseList
+  rule <k> #eval(chooseList,
                      (ListItem(< con list(_T:TypeConstant) [ .ConstantList ] >)
                       ListItem(V1:Value)
-                      ListItem(_V2:Value)) 0 > => V1 ... </k>
+                      ListItem(_V2:Value))) => V1 ... </k>
 
-  rule <k> < builtin chooseList
-                     (ListItem(< con list(_T:TypeConstant) [ _L:ConstantList ] >)
+  rule <k> #eval(chooseList,
+                     (ListItem(< con list(_T:TypeConstant) [ L:ConstantList ] >)
                       ListItem(_V1:Value)
-                      ListItem(V2:Value)) 0 > => V2 ... </k> [owise]
+                      ListItem(V2:Value))) => V2 ... </k>
+  requires L =/=K .ConstantList
+
+  rule <k> #eval(chooseList, _) => (error) ... </k> [owise]
 ```
 
 ## `mkCons`
@@ -122,10 +134,12 @@ module UPLC-POLYMORPHIC-BUILTINS
 ```k
   rule <k> (builtin mkCons) ~> Force => < builtin mkCons .List 2 > ... </k>
 
-  rule <k> < builtin mkCons
+  rule <k> #eval(mkCons,
               (ListItem(< con T:TypeConstant C:Constant >)
-               ListItem(< con list(T) [ L:ConstantList ] >)) 0 > =>
+               ListItem(< con list(T) [ L:ConstantList ] >))) =>
            < con list(T) [ C , L ] > ... </k>
+
+  rule <k> #eval(mkCons, _) => (error) ... </k> [owise]
 ```
 
 ## `headList`
@@ -133,12 +147,12 @@ module UPLC-POLYMORPHIC-BUILTINS
 ```k
   rule <k> (builtin headList) ~> Force => < builtin headList .List 1 > ... </k>
 
-  rule <k> < builtin headList
+  rule <k> #eval(headList,
               ListItem(< con list(T:TypeConstant)
-                                 [ C:Constant  , _L:ConstantList ] >) 0 > =>
+                                 [ C:Constant  , _L:ConstantList ] >)) =>
            (con T C) ... </k>
 
-  rule <k> < builtin headList _ 0 > => (error) ... </k> [owise]
+  rule <k> #eval(headList, _) => (error) ... </k> [owise]
 
 ```
 
@@ -147,13 +161,15 @@ module UPLC-POLYMORPHIC-BUILTINS
 ```k
   rule <k> (builtin tailList) ~> Force => < builtin tailList .List 1 > ... </k>
 
-  rule <k> < builtin tailList
-              ListItem(< con list(T:TypeConstant) [ .ConstantList ] >) 0 > =>
+  rule <k> #eval(tailList,
+              ListItem(< con list(T:TypeConstant) [ .ConstantList ] >)) =>
            < con T [ .ConstantList ] > ... </k>
 
-  rule <k> < builtin tailList
-              ListItem(< con list(T:TypeConstant) [ _C:Constant , L:ConstantList ] >) 0 > =>
+  rule <k> #eval(tailList,
+              ListItem(< con list(T:TypeConstant) [ _C:Constant , L:ConstantList ] >)) =>
            < con T [ L ] > ... </k>
+
+  rule <k> #eval(tailList, _) => (error) ... </k> [owise]
 ```
 
 ## `nullList`
@@ -161,11 +177,16 @@ module UPLC-POLYMORPHIC-BUILTINS
 ```k
   rule <k> (builtin nullList) ~> Force => < builtin nullList .List 1 > ... </k>
 
-  rule <k> < builtin nullList
-              ListItem(< con list(_T:TypeConstant) [ .ConstantList ] >) 0 > =>
+  rule <k> #eval(nullList,
+              ListItem(< con list(_T:TypeConstant) [ .ConstantList ] >)) =>
            < con bool True > ... </k>
 
-  rule <k> < builtin nullList _ 0 > => < con bool False > ... </k> [owise]
+  rule <k> #eval(nullList,
+              ListItem(< con list(_T:TypeConstant) [ L:ConstantList ] >)) =>
+           < con bool False > ... </k>
+  requires L =/=K .ConstantList 
+
+  rule <k> #eval(nullList, _) => (error) ... </k> [owise]
 ```
 
 ## `trace`
@@ -173,10 +194,12 @@ module UPLC-POLYMORPHIC-BUILTINS
 ```k
   rule <k> (builtin trace) ~> Force => < builtin trace .List 2 > ... </k>
 
-  rule <k> < builtin trace
+  rule <k> #eval(trace, 
               (ListItem(< con string S >)
-               ListItem(V:Value)) 0 > => V ... </k>
+               ListItem(V:Value))) => V ... </k>
        <trace> ... (.List => ListItem(S)) </trace>
+
+  rule <k> #eval(trace, _) => (error) ... </k> [owise]
 ```
 
 ```k

--- a/uplc-semantics.md
+++ b/uplc-semantics.md
@@ -56,7 +56,10 @@ module UPLC-SEMANTICS
 
   rule <k> V:Value ~> [ < builtin BN:BuiltinName L:List I:Int > _] =>
            < builtin BN (L ListItem(V)) (I -Int 1) > ... </k>
-  requires I >Int 0
+  requires I >Int 1
+
+  rule <k> V:Value ~> [ < builtin BN:BuiltinName L:List 1 > _] =>
+           #eval(BN, (L ListItem(V))) ... </k>
 ```
 
 ```k

--- a/uplc-string-builtins.md
+++ b/uplc-string-builtins.md
@@ -17,8 +17,10 @@ module UPLC-STRING-BUILTINS
 ```k 
   rule <k> (builtin encodeUtf8) => < builtin encodeUtf8 .List 1 > ... </k>
 
-  rule <k> < builtin encodeUtf8 ListItem(< con string S:String >) 0 > =>
+  rule <k> #eval(encodeUtf8, ListItem(< con string S:String >)) =>
            < con bytestring #encodeUtf8(S) > ... </k>
+
+  rule <k> #eval(encodeUtf8, _) => (error) ... </k> [owise]
 ```
 
 ## `decodeUtf8`
@@ -26,8 +28,11 @@ module UPLC-STRING-BUILTINS
 ```k 
   rule <k> (builtin decodeUtf8) => < builtin decodeUtf8 .List 1 > ... </k>
 
-  rule <k> < builtin decodeUtf8 ListItem(< con bytestring B:ByteString >) 0 > =>
+  rule <k> #eval(decodeUtf8, ListItem(< con bytestring B:ByteString >)) =>
            < con string #decodeUtf8(B) > ... </k>
+
+  rule <k> #eval(decodeUtf8, _) => (error) ... </k> [owise]
+
 ```
 
 ## `appendString`
@@ -35,10 +40,12 @@ module UPLC-STRING-BUILTINS
 ```k 
   rule <k> (builtin appendString) => < builtin appendString .List 2 > ... </k>
 
-  rule <k> < builtin appendString
+  rule <k> #eval(appendString,
               (ListItem(< con string S1:String >)
-               ListItem(< con string S2:String >)) 0 > =>
+               ListItem(< con string S2:String >))) =>
            < con string #appendString(S1, S2) > ... </k>
+
+  rule <k> #eval(appendString, _) => (error) ... </k> [owise]
 ```
 
 ## `equalsString`
@@ -46,13 +53,19 @@ module UPLC-STRING-BUILTINS
 ```k 
   rule <k> (builtin equalsString) => < builtin equalsString .List 2 >  ... </k>
 
-  rule <k> < builtin equalsString
+  rule <k> #eval(equalsString,
               (ListItem(< con string S1:String >)
-               ListItem(< con string S2:String >)) 0 > =>
+               ListItem(< con string S2:String >))) =>
            < con bool True > ... </k>
   requires #equalsString(S1, S2)
 
-  rule <k> < builtin equalsString _ 0 > => < con bool False > ... </k> [owise]
+  rule <k> #eval(equalsString,
+              (ListItem(< con string S1:String >)
+               ListItem(< con string S2:String >))) =>
+           < con bool False > ... </k>
+  requires notBool #equalsString(S1, S2)
+
+  rule <k> #eval(equalsString, _) => (error) ... </k> [owise]
 ```
 
 ```k


### PR DESCRIPTION
Even though this is a large PR, in terms of the number of modified lines of code, the modification is simple with respect to #135. Builtin evaluation relies on decrementing the number of arguments it expects in order to actually call the proper builtin function that does the job. This decrementing was being computed all the way down to 0. It led however to states such as `V ~> [ < builtin bn L 0 > _]`, where `V` is a Value, `bn` is a builtin name, and `L` is a (semantic) list with the arguments of `bn`. There are no such rule to further reduce such states. What needs to be done is to let evaluation go down to 1 and then directly call the function that does the job, where states as above are not reachable. 

So this PR essentially changes builtin evaluation to 
```
  rule <k> V:Value ~> [ < builtin BN:BuiltinName L:List I:Int > _] =>
           < builtin BN (L ListItem(V)) (I -Int 1) > ... </k>
  requires I >Int 1

  rule <k> V:Value ~> [ < builtin BN:BuiltinName L:List 1 > _] =>
           #eval(BN, (L ListItem(V))) ... </k>
```
and adapts every builtin to cope with them, which means essentially to implement the function that does the job as an `#eval` function.