### PR TITLE
Enable K unit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *~
 **/#*
 *.sh
+unit-tests/verification/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
           failFast true
           options { timeout(time: 20, unit: 'MINUTES') }
           parallel {
+            stage('proof tests')                   { steps { sh 'make test-prove -j4 --output-sync=recurse'                         } }
             stage('Simple')                        { steps { sh 'make test-simple -j4 --output-sync=recurse'                        } }
             stage('uplc-examples')                 { steps { sh 'make test-uplc-examples -j4 --output-sync=recurse'                 } }
             stage('benchmark-validation-examples') { steps { sh 'make test-benchmark-validation-examples -j4 --output-sync=recurse' } }

--- a/Makefile
+++ b/Makefile
@@ -322,15 +322,15 @@ uninstall:
 #------------
 KPROVE_OPTS :=
 
-test-prove: unit-tests/flat-unit-test.md.prove
+prove_tests := $(wildcard unit-tests/*.md)
 
-unit-tests/flat-unit-test.md.prove: unit-tests/flat-unit-test.md unit-tests/verification/haskell/verification-kompiled/timestamp
+test-prove: $(prove_tests:=.prove)
+
+unit-tests/%.md.prove: unit-tests/%.md unit-tests/verification/haskell/verification-kompiled/timestamp
 	$(KPLUTUS) prove --directory unit-tests/verification/haskell $< $(KPROVE_OPTS)
 
 unit-tests/verification/haskell/verification-kompiled/timestamp: unit-tests/verification.k $(kplutus_includes)
 	$(KOMPILE) --backend haskell $< --directory unit-tests/verification/haskell
-
-unit-tests/flat-unit-test.md.prove: unit-tests/flat-unit-test.md
 
 
 # Testing

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,8 @@ export PLUGIN_SUBMODULE
         test-benchmark-validation-examples \
         test-nofib-exe-examples            \
         conformance-test                   \
-        update-results
+        update-results                     \
+        test-prove
 
 .SECONDARY:
 
@@ -316,6 +317,21 @@ $(DESTDIR)$(INSTALL_LIB)/%: $(KPLUTUS_LIB)/%
 uninstall:
 	rm -rf $(DESTDIR)$(INSTALL_BIN)/kplutus
 	rm -rf $(DESTDIR)$(INSTALL_LIB)/kplutus
+
+# Prove tests
+#------------
+KPROVE_OPTS :=
+
+test-prove: unit-tests/flat-unit-test.md.prove
+
+unit-tests/flat-unit-test.md.prove: unit-tests/flat-unit-test.md unit-tests/verification/haskell/verification-kompiled/timestamp
+	$(KPLUTUS) prove --directory unit-tests/verification/haskell $< $(KPROVE_OPTS)
+
+unit-tests/verification/haskell/verification-kompiled/timestamp: unit-tests/verification.k $(kplutus_includes)
+	$(KOMPILE) --backend haskell $< --directory unit-tests/verification/haskell
+
+unit-tests/flat-unit-test.md.prove: unit-tests/flat-unit-test.md
+
 
 # Testing
 # -------

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,22 @@ plugin-deps: $(plugin_includes) $(plugin_c_includes)
 
 KOMPILE := $(KPLUTUS) kompile
 
-kplutus_files := uplc.md 
+kplutus_files := uplc.md \
+                 bitstream.md \
+                 uplc-bytestring-builtins.md \
+                 uplc-crypto-builtins.md  \
+                 uplc-integer-builtins.md \
+                 uplc-semantics.md \
+                 uplc-syntax.md \
+                 uplc-bytestring.md \
+                 uplc-environment.md \
+                 uplc.md \
+                 uplc-string-builtins.md \
+                 uplc-configuration.md \
+                 uplc-flat-parser.md \
+                 uplc-polymorphic-builtins.md \
+                 uplc-string.md
+
 
 kplutus_includes := $(patsubst %, $(KPLUTUS_INCLUDE)/kframework/%, $(kplutus_files))
 
@@ -227,8 +242,6 @@ haskell_main_file      := uplc.md
 haskell_main_filename  := $(basename $(notdir $(haskell_main_file)))
 haskell_kompiled       := $(haskell_dir)/$(haskell_main_filename)-kompiled/definition.kore
 
-foo:
-	echo $(kplutus_includes)
 
 ifndef NOBUILD_CRYPTOPP
   $(KPLUTUS_LIB)/$(llvm_kompiled): $(libcryptopp_out)
@@ -278,7 +291,7 @@ $(KPLUTUS_LIB)/release.md: INSTALL.md
 
 build: $(patsubst %, $(KPLUTUS_BIN)/%, $(install_bins)) $(patsubst %, $(KPLUTUS_LIB)/%, $(install_libs))
 
-build-kplutus: $(KPLUTUS_BIN)/kplc $(plugin_includes)
+build-kplutus: $(KPLUTUS_BIN)/kplc $(plugin_includes) $(kplutus_includes)
 build-llvm:    $(KPLUTUS_LIB)/$(llvm_kompiled)
 build-haskell: $(KPLUTUS_LIB)/$(haskell_kompiled)
 

--- a/kplc
+++ b/kplc
@@ -99,7 +99,7 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
                   --debug
                   --verbose
                   --backend
-                  --backend-dir
+                  --directory
                   --flat-format : The input program is encoded in the flat format
     "
     exit 0
@@ -128,7 +128,7 @@ while [[ $# -gt 0 ]]; do
         --flat-format) flat_format=true                ; shift   ;;
         --verbose)     verbose=true                    ; shift   ;;
         --backend)     backend="$2"                    ; shift 2 ;;
-        --backend-dir) backend_dir="$2"                ; shift 2 ;;
+        --directory)   backend_dir="$2"                ; shift 2 ;;
         --result-only) result_only=true                ; shift   ;;
         *)             args+=("$1")                    ; shift   ;;
     esac

--- a/kplc
+++ b/kplc
@@ -73,6 +73,23 @@ run_interpreter() {
         | (${result_only} && ( tr '\n' ' ' | sed "s/.*<k>\(.*\)~> \. .*/\1/g" ) || cat - )
 }
 
+run_prove() {
+    local def_module run_dir proof_args bug_report_name \
+          eventlog_name kprove omit_cells omit_labels klab_log pyk_args
+
+    bug_report_name="kplc-bug-$(basename "${run_file%-spec.k}")"
+    eventlog_name="${run_file}.eventlog"
+
+    proof_args=(--directory "${backend_dir}" "${run_file}")
+    proof_args+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
+
+    ! ${bug_report} || proof_args+=(--haskell-backend-command "kore-exec --bug-report ${bug_report_name}")
+    ! ${debugger}   || proof_args+=(--debugger)
+
+    notif_exec kprovex "${proof_args[@]}" "$@"
+}
+
+
 # Main
 # ----
 
@@ -113,24 +130,21 @@ fi
 
 result_only=false
 backend='llvm'
-
-if [[ "$run_command" == 'run-haskell' ]]; then
-    run_command='run'
-    backend='haskell'
-else
-    backend='llvm'
-fi
+bug_report=false
+debugger=false
 
 args=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --debug)       debug=true       ; args+=("$1") ; shift   ;;
-        --flat-format) flat_format=true                ; shift   ;;
-        --verbose)     verbose=true                    ; shift   ;;
-        --backend)     backend="$2"                    ; shift 2 ;;
-        --directory)   backend_dir="$2"                ; shift 2 ;;
-        --result-only) result_only=true                ; shift   ;;
-        *)             args+=("$1")                    ; shift   ;;
+        --debug)        debug=true       ; args+=("$1") ; shift   ;;
+        --flat-format)  flat_format=true                ; shift   ;;
+        --verbose)      verbose=true                    ; shift   ;;
+        --backend)      backend="$2"                    ; shift 2 ;;
+        --directory)    backend_dir="$2"                ; shift 2 ;;
+        --result-only)  result_only=true                ; shift   ;;
+        --bug-report)   bug_report=true                 ; shift   ;;
+        --debugger)     debugger=true                   ; shift   ;;
+        *)              args+=("$1")                    ; shift   ;;
     esac
 done
 
@@ -147,10 +161,9 @@ if ${flat_format}; then
     run_file="${run_file}".hex
 fi
 
-case "$run_command-$backend" in
-    kompile-llvm)    run_kompile     "$@"                                                ;;
-    kompile-haskell) run_kompile     "$@"                                                ;;
-    run-llvm)        run_interpreter "$@"                                                ;;
-    run-haskell)     run_interpreter "$@"                                                ;;
-    *)               $0 help ; fatal "Unknown command on backend: $run_command $backend" ;;
+case "${run_command}" in
+    kompile)    run_kompile     "$@"                                                ;;
+    run)        run_interpreter "$@"                                                ;;
+    prove)      run_prove       "$@"                                                ;;
+    *)          $0 help ; fatal "Unknown command: ${run_command}" ;;
 esac

--- a/unit-tests/flat-unit-test.md
+++ b/unit-tests/flat-unit-test.md
@@ -1,0 +1,10 @@
+```k
+requires "verification.k"
+
+module FLAT-UNIT-TEST
+  imports VERIFICATION
+
+  claim <k> simplify(#bit2boolval(0)) => simplified(False) </k>
+
+endmodule
+```

--- a/unit-tests/verification.k
+++ b/unit-tests/verification.k
@@ -1,0 +1,11 @@
+requires "uplc.md"
+
+module VERIFICATION
+  imports UPLC
+
+  syntax KItem ::= simplify(KItem)
+                 | simplified(KItem)
+
+  rule <k> simplify(K) => simplified(K) ... </k>
+
+endmodule


### PR DESCRIPTION
Components such as the flat parser requires programming many functions
before a realistic program can be parsed as input. To facilitate
development, enable unit testing and add a new target
`make run-unit-tests` in order to execute the unit tests. Each test is
written as a claim inside of a md file in the unit-tests directory.