### PR TITLE
Fix non-iterative application

### DIFF
--- a/tests/simple/subtractInteger-non-iter.uplc
+++ b/tests/simple/subtractInteger-non-iter.uplc
@@ -1,0 +1,1 @@
+(program 1.0.0 [ [ (builtin subtractInteger) (con integer 1)] (con integer 2) ])

--- a/tests/simple/subtractInteger-non-iter.uplc.expected
+++ b/tests/simple/subtractInteger-non-iter.uplc.expected
@@ -1,0 +1,1 @@
+(con integer -1)

--- a/tests/simple/subtractInteger-non-iter.uplc.krun.expected
+++ b/tests/simple/subtractInteger-non-iter.uplc.krun.expected
@@ -1,0 +1,11 @@
+<generatedTop>
+  <k>
+    [] ( con integer -1 ) ~> .
+  </k>
+  <env>
+    .Env
+  </env>
+  <trace>
+    .List
+  </trace>
+</generatedTop>

--- a/uplc-semantics.md
+++ b/uplc-semantics.md
@@ -22,9 +22,11 @@ module UPLC-SEMANTICS
                       | "[]" "(" "delay" Term ")"
 
   syntax K ::= #app(Term, TermList, Env) [function]
+  rule #app(M:Term, (N:Term T:TermList), RHO:Env) => #appAux(T, M ~> [_ N RHO ], RHO)
 
-  rule #app(M, .TermList, _RHO) => M
-  rule #app(M, (N:Term T:TermList), RHO) => #app(M, T, RHO) ~> [_ N RHO ] [owise]
+  syntax K ::= #appAux(TermList, K, Env) [function]
+  rule #appAux(.TermList, K:K, RHO:Env) => K
+  rule #appAux((N:Term T:TermList), K:K, RHO:Env) => #appAux(T, K ~> [_ N RHO], RHO) 
 ```
 
 ## CEK machine


### PR DESCRIPTION
Applications of the form `[M N1 N2 ... Nn]` are translated into (the denotation of) `[... [M N1] N2] ...] Nn]`.
However, the arguments were being pushed in the wrong order. This PR fixes it.