### PR TITLE
change function application to use heaps

### DIFF
--- a/uplc-configuration.md
+++ b/uplc-configuration.md
@@ -41,6 +41,8 @@ is used to keep track of the data emitted by the `trace` builtin.
 
   configuration <k> #handleProgram($PGM:Program) </k>
                 <env> .Env </env>
+                <heap> .Map </heap>
+                <current> 0 </current>
                 <trace> .List </trace>
 ```
 

--- a/uplc-environment.md
+++ b/uplc-environment.md
@@ -8,9 +8,11 @@ module UPLC-ENVIRONMENT
   imports UPLC-ID
   imports BOOL
   imports K-EQUAL
+  imports MAP
 
   syntax Bindable
-  syntax Bind ::= bind(UplcId, Bindable)
+  syntax Bind ::= bind(UplcId, Int)
+
   syntax Env ::= List{Bind,""} 
 
   syntax Bool ::= #in(Env, UplcId) [function]
@@ -19,9 +21,9 @@ module UPLC-ENVIRONMENT
   rule #in(bind(Y:UplcId, _) E:Env, X:UplcId) => #in(E, X)
   requires X =/=K Y
   
-  syntax Bindable ::= #lookup(Env, UplcId) [function]
-  rule #lookup(bind(X:UplcId, V:Bindable) _, X:UplcId) => V
-  rule #lookup(bind(X:UplcId, _) E:Env, Y:UplcId) => #lookup(E, Y)
+  syntax Value ::= #lookup(Env, UplcId, Map) [function]
+  rule #lookup(bind(X:UplcId, I:Int) _, X:UplcId, M:Map) => {M[I]}:>Value
+  rule #lookup(bind(X:UplcId, _) E:Env, Y:UplcId, M:Map) => #lookup(E, Y, M)
   requires X =/=K Y
 
   syntax Env ::= #push(Env, Bind) [function]

--- a/uplc-semantics.md
+++ b/uplc-semantics.md
@@ -16,6 +16,7 @@ module UPLC-SEMANTICS
   imports UPLC-STRING-BUILTINS
   imports UPLC-DATA-BUILTINS
   imports INT
+  imports MAP
 
   syntax Bindable ::= Value
 
@@ -36,8 +37,9 @@ module UPLC-SEMANTICS
 ```k
   rule <k> (program _V M) => M </k>
 
-  rule <k> X:UplcId => #lookup(RHO, X) ... </k>
+  rule <k> X:UplcId => #lookup(RHO, X, Heap) ... </k>
        <env> RHO </env>
+       <heap> Heap </heap>
 
   rule <k> (con T:TypeConstant C:Constant) =>
            < con T:TypeConstant C:Constant > ... </k>
@@ -57,7 +59,9 @@ module UPLC-SEMANTICS
        <env> _ => RHO </env>
 
   rule <k> V:Value ~> [ < lam X:UplcId M:Term RHO:Env > _] => M ... </k>
-       <env> _ => #push(RHO, bind(X, V)) </env>
+       <env> _ => #push( RHO, bind( X, I ) ) </env>
+       <heap> Heap => Heap[  I <- V ] </heap>
+       <current> I => I +Int 1 </current>
 
   rule <k> < delay M:Term RHO:Env > ~> Force => M ... </k>
        <env> _ => RHO:Env </env>


### PR DESCRIPTION
This PR adds the notion of a _heap_ to KPlutus aiming at reducing duplications on the term at the K cell.

Each value in UPLC has its own environment. That generates a lot of copies of bindings on a given term. Instead of repeating the terms we simply add a reference to it in the heap.

There has been a change in the behavior regarding files in `tests/benchmark-validation-examples/`: files that filled up `result.kore` now reach a stuck state. But this does still require further analysis and experimentation for instance by truely sharing heap elements instead of just referencing potentially replicated terms.

Developed by: @SchmErik 