### PR TITLE
Remove non-iteractive application

### DIFF
--- a/tests/failing
+++ b/tests/failing
@@ -14,6 +14,11 @@ tests/simple/var.uplc
 # ifThenElse needs to be composed with force
 # We need to improve error report to cope with `uplc` output.
 tests/simple/ifThenElse-no-force.uplc
+# Non-iterative application is not supported
+tests/simple/addInteger-uncurried.uplc
+# Factorial of 1000 generates a segmentation fault.
+# It seems to be due to the large heap.
+tests/uplc-examples/factorial2.uplc
 #
 # UPLC examples 
 #

--- a/uplc-syntax.md
+++ b/uplc-syntax.md
@@ -32,7 +32,7 @@ module UPLC-SYNTAX
                 | "(" "con" TypeConstant Constant ")"
                 | "(" "builtin" BuiltinName ")"
                 | "(" "lam" UplcId Term ")"
-                | "[" Term TermList "]"
+                | "[" Term Term "]"
                 | "(" "delay" Term ")"
                 | "(" "force" Term ")"
                 | "(" "error" ")"
@@ -41,8 +41,6 @@ module UPLC-SYNTAX
                  | "<" "lam" UplcId Term Env ">"
                  | "<" "delay" Term Env ">"
                  | "<" "builtin" BuiltinName List Int ">"
-
-  syntax TermList ::= NeList{Term, ""}
 
   syntax TypeConstant ::= "integer"
                         | "data"


### PR DESCRIPTION
* The semantics for non-iteractive application was incorrect. It would
  be necessary to distribute the term being applied to its arguments
  and that would depend on the arity of the function. Since this is
  not specified in the CEK machine for UPLC and is not (fully, at
  least) supported by `uplc`, this commit removes it from the
  semantics. Only applications of the form `[Term Term]` are allowed.

* Test `tests/uplc-examples/factorial2.uplc` (that calculates the
  factorial of 1000) segfaults. It seems that the large heap is the
  source of the problem. It is not really related to the main subject but it broke my test. So I decided to add it to tests/failing