### PR TITLE
Makefile: add build-coverage and coverage targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,8 @@ export PLUGIN_SUBMODULE
         test-uplc-examples                 \
         test-benchmark-validation-examples \
         test-nofib-exe-examples            \
-        conformance-test                   \
-        update-results                     \
-        test-prove
+        conformance-test update-results    \
+        test-prove fresh-test-coverage
 
 .SECONDARY:
 
@@ -330,6 +329,14 @@ $(DESTDIR)$(INSTALL_LIB)/%: $(KPLUTUS_LIB)/%
 uninstall:
 	rm -rf $(DESTDIR)$(INSTALL_BIN)/kplutus
 	rm -rf $(DESTDIR)$(INSTALL_LIB)/kplutus
+
+procs := $(shell nproc)
+
+fresh-test-coverage:
+	rm -r $(KPLUTUS_LIB)/$(llvm_kompiled_dir)
+	make build-coverage
+	make conformance-test -j$(procs)
+	make coverage
 
 # Prove tests
 #------------

--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,9 @@ export PLUGIN_SUBMODULE
 
 .PHONY: all clean distclean                \
         deps k-deps plugin-deps libff      \
-        build build-kplutus build-haskell  \
-        build-llvm install uninstall       \
+        build build-coverage build-kplutus \
+        build-haskell build-llvm           \
+        install uninstall                  \
         test-new-syntax test-simple        \
         test-uplc-examples                 \
         test-benchmark-validation-examples \
@@ -236,7 +237,8 @@ llvm_main_module   := UPLC
 llvm_syntax_module := UPLC-SYNTAX
 llvm_main_file     := uplc.md
 llvm_main_filename := $(basename $(notdir $(llvm_main_file)))
-llvm_kompiled      := $(llvm_dir)/$(llvm_main_filename)-kompiled/interpreter
+llvm_kompiled_dir  := $(llvm_dir)/$(llvm_main_filename)-kompiled/
+llvm_kompiled      := $(llvm_kompiled_dir)/interpreter
 
 haskell_dir            := haskell
 haskell_main_module    := UPLC
@@ -263,6 +265,12 @@ $(KPLUTUS_LIB)/$(haskell_kompiled): $(kplutus_includes) $(plugin_includes) $(KPL
 	    --main-module $(haskell_main_module)         \
 	    --syntax-module $(haskell_syntax_module)     \
 	    $(KOMPILE_OPTS)
+
+# Coverage Processing
+# -------------------
+
+coverage:
+	kcovr $(KPLUTUS_LIB)/$(llvm_kompiled_dir) -- $(kplutus_includes) > $(BUILD_DIR)/coverage.xml
 
 # Installing
 # ----------
@@ -293,6 +301,9 @@ $(KPLUTUS_LIB)/release.md: INSTALL.md
 	cat INSTALL.md                                >> $@
 
 build: $(patsubst %, $(KPLUTUS_BIN)/%, $(install_bins)) $(patsubst %, $(KPLUTUS_LIB)/%, $(install_libs))
+
+build-coverage: KOMPILE_OPTS += --coverage
+build-coverage: $(KPLUTUS_LIB)/$(llvm_kompiled)
 
 build-kplutus: $(KPLUTUS_BIN)/kplc $(plugin_includes) $(kplutus_includes)
 build-llvm:    $(KPLUTUS_LIB)/$(llvm_kompiled)

--- a/README.md
+++ b/README.md
@@ -54,13 +54,11 @@ Rule Coverage
 This project contains facilities to generate coverage metrics for K rewrite rules that were executed by `kplc run`.
 This is helpful in ensuring that the test suite contains input programs that exercise all rewrite rules in the semantics.
 
-To generate this information, run the following sequence of commands:
+To generate this information, run the following command:
 
 ```
-  make build-coverage
-  make conformance-test
-  make coverage
+  make fresh-test-coverage
 ```
 
-This sequence of commands generates a `.build/coverage.xml` file. This file contains information
-about the k rewrite rules that have been exercised while `make conformance-test` was running.
+This command generates a `.build/coverage.xml` file. This file contains information about the K
+rewrite rules that have been exercised for all tests in the tests/ directory.

--- a/README.md
+++ b/README.md
@@ -47,3 +47,20 @@ Testing
 
 -   Update test results: `make update-results`
     Update all test results. Note: this requires having the uplc program installed in the machine's PATH.
+
+Rule Coverage
+-------------
+
+This project contains facilities to generate coverage metrics for K rewrite rules that were executed by `kplc run`.
+This is helpful in ensuring that the test suite contains input programs that exercise all rewrite rules in the semantics.
+
+To generate this information, run the following sequence of commands:
+
+```
+  make build-coverage
+  make conformance-test
+  make coverage
+```
+
+This sequence of commands generates a `.build/coverage.xml` file. This file contains information
+about the k rewrite rules that have been exercised while `make conformance-test` was running.


### PR DESCRIPTION
These targets generate coverage information of K rewrite rules. The
following sequence of commands generates a `.build/coverage.xml` file
that contains information about the rules that have been exercised
during the execution of `make conformance-test`.

```
  make build-coverage
  make conformance-test
  make coverage
```

The information found in the xml file can help us determine which test
cases need to be added to ensure that our test suite exercises all rules.