### PR TITLE
Add support for non-interactive application

### DIFF
--- a/tests/failing
+++ b/tests/failing
@@ -14,8 +14,6 @@ tests/simple/var.uplc
 # ifThenElse needs to be composed with force
 # We need to improve error report to cope with `uplc` output.
 tests/simple/ifThenElse-no-force.uplc
-# Non-iterative application is not supported yet.
-tests/simple/addInteger-uncurried.uplc
 # Programs addInteger-one-arg.uplc and addInteger-no-arg.uplc call
 # addInteger with a single argument or none. In the current semantics,
 # kplc returns an error. However, they are valid programs as

--- a/tests/simple/addInteger-non-interactive.uplc
+++ b/tests/simple/addInteger-non-interactive.uplc
@@ -1,0 +1,1 @@
+(program 0.0.0 [(builtin addInteger) (con integer 1) (con integer 1)])

--- a/tests/simple/addInteger-non-interactive.uplc.expected
+++ b/tests/simple/addInteger-non-interactive.uplc.expected
@@ -1,0 +1,1 @@
+      ( con integer 2 ) 

--- a/tests/simple/subtractInteger-non-interactive.uplc
+++ b/tests/simple/subtractInteger-non-interactive.uplc
@@ -1,0 +1,1 @@
+(program 0.0.0 [(builtin subtractInteger) (con integer 1) (con integer 4)])

--- a/tests/simple/subtractInteger-non-interactive.uplc.expected
+++ b/tests/simple/subtractInteger-non-interactive.uplc.expected
@@ -1,0 +1,1 @@
+      ( con integer -3 ) 

--- a/uplc-semantics.md
+++ b/uplc-semantics.md
@@ -51,7 +51,14 @@ module UPLC-SEMANTICS
   rule <k> < delay M:Term RHO:Map > ~> Force => M ... </k>
        <env> _ => RHO:Map </env>
 
-  rule <k> [ M N ] => M ~> [_ N RHO ] ... </k>
+  syntax K ::= #app(Term, TermList, Map) [function]
+  syntax K ::= #appAux(TermList, Map) [function]
+
+  rule #app(M:Term, TL:TermList, RHO:Map) => M ~> #appAux(TL, RHO)
+  rule #appAux(N:Term .TermList, RHO) => [_ N RHO ]
+  rule #appAux(N:Term TL:TermList, RHO) => [_ N RHO ] ~> #appAux(TL, RHO) [owise]
+
+  rule <k> [ M:Term TL:TermList ] => #app(M, TL, RHO) ... </k>
        <env> RHO:Map </env>
 
   rule <k> V:Value ~> [_ M RHO:Map ] => M ~> [ V _] ... </k>

--- a/uplc-syntax.md
+++ b/uplc-syntax.md
@@ -32,10 +32,12 @@ module UPLC-SYNTAX
                 | "(" "con" TypeConstant Constant ")"
                 | "(" "builtin" BuiltinName ")"
                 | "(" "lam" UplcId Term ")"
-                | "[" Term Term "]"
+                | "[" Term TermList "]"
                 | "(" "delay" Term ")"
                 | "(" "force" Term ")"
                 | "(" "error" ")"
+
+  syntax TermList ::= NeList{Term, ""}
 
   syntax Value ::= "<" "con" TypeConstant Constant ">"
                  | "<" "lam" UplcId Term Map ">"


### PR DESCRIPTION
This PR returns support for non-iterative application. A program such as
```
(program 0.0.0 [(builtin subtractInteger) (con integer 1) (con integer 4)])

```
is equivalently to
```
(program 0.0.0 [ [(builtin subtractInteger) (con integer 1) ] (con integer 4)])

```
However,
```
(program 0.0.0 [(builtin subtractInteger) (con integer 1) (con integer 4) (con integer 0)])

```
is neither supported by `kplc` nor `uplc`.