### PR TITLE
Add partial application as final state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,8 @@ kplutus_files := uplc.md \
                  uplc-polymorphic-builtins.md \
                  uplc-string.md \
                  uplc-data-builtins.md \
-                 uplc-hash.md
+                 uplc-hash.md \
+		 uplc-pretty-print.md
 
 kplutus_includes := $(patsubst %, $(KPLUTUS_INCLUDE)/kframework/%, $(kplutus_files))
 
@@ -270,7 +271,8 @@ $(KPLUTUS_LIB)/$(haskell_kompiled): $(kplutus_includes) $(plugin_includes) $(KPL
 
 covr_ignore_files := bitstream.md \
                      uplc-bytestring.md \
-                     uplc-flat-parser.md
+                     uplc-flat-parser.md \
+		     uplc-pretty-print.md
 
 covr_ignore_includes := $(patsubst %, $(KPLUTUS_INCLUDE)/kframework/%, $(covr_ignore_files))
 

--- a/tests/simple/part-app.uplc
+++ b/tests/simple/part-app.uplc
@@ -1,0 +1,1 @@
+(program 0.0.0 [(builtin addInteger) (con integer 0)])

--- a/tests/simple/part-app.uplc.expected
+++ b/tests/simple/part-app.uplc.expected
@@ -1,0 +1,1 @@
+[ (builtin addInteger) (con integer 0) ]

--- a/uplc-pretty-print.md
+++ b/uplc-pretty-print.md
@@ -1,0 +1,32 @@
+# UPLC Pretty-Print
+
+```k
+requires "uplc-syntax.md"
+
+module UPLC-PRETTY-PRINT
+  imports INT
+  imports LIST
+  imports UPLC-SYNTAX
+  
+  syntax Term ::= prettyPrint(Value) [function]
+  syntax TermList ::= list2TermList(List) [function]
+  
+  rule list2TermList(.List) => .TermList
+
+  rule list2TermList(ListItem(V:Value)) =>
+       prettyPrint(V) 
+  
+  rule list2TermList(L:List) =>
+       prettyPrint({L[0]}:>Value) list2TermList(range(L, 1, size(L)))
+  requires size(L) >Int 1
+
+  rule prettyPrint(< con T:TypeConstant C:Constant >) => (con T C) 
+
+  rule prettyPrint(< lam I:UplcId T:Term _ >) => (lam I T) 
+
+  rule prettyPrint(< delay T:Term _ >) => (delay T) 
+
+  rule prettyPrint(< builtin BN:BuiltinName L:List _ >) =>
+       [ (builtin BN) list2TermList(L) ] 
+endmodule
+```

--- a/uplc-semantics.md
+++ b/uplc-semantics.md
@@ -8,6 +8,7 @@ require "uplc-crypto-builtins.md"
 require "uplc-string-builtins.md"
 require "uplc-data-builtins.md"
 require "uplc-hash.md"
+require "uplc-pretty-print.md"
 
 module UPLC-SEMANTICS
   imports INT
@@ -19,12 +20,11 @@ module UPLC-SEMANTICS
   imports UPLC-STRING-BUILTINS
   imports UPLC-DATA-BUILTINS
   imports UPLC-HASH
+  imports UPLC-PRETTY-PRINT
 
   syntax Bindable ::= Value
 
-  syntax FinalState ::= "[]" "(" "con" TypeConstant Constant ")"
-                      | "[]" "(" "lam" UplcId Term ")"
-                      | "[]" "(" "delay" Term ")"
+  syntax FinalState ::= "[]" Term
 ```
 
 ## CEK machine
@@ -75,17 +75,11 @@ module UPLC-SEMANTICS
            < builtin BN (L ListItem(V)) (I -Int 1) > ... </k>
   requires I >Int 1
 
-  rule <k> < con T:TypeConstant C:Constant > ~> . => [] (con T C) </k>
-
-  rule <k> < lam I:UplcId T:Term _ > ~> . => [] (lam I T) </k>
-
-  rule <k> < delay T:Term _ > ~> . => [] (delay T) </k>
-
   rule <k> _V:Value ~> [ < con _ _ > _] ~> _ => (error) </k>
 
   rule <k> _V:Value ~> [ < delay _ _ > _] ~> _ => (error) </k>
 
-  rule <k> < builtin _ _ _ > ~> . => (error) </k>
+  rule <k> V:Value ~> . => [] prettyPrint(V) </k>
 ```
 
 ```k


### PR DESCRIPTION
Partial applications are also values that should be properly
pretty-printed. They are naturally computed with by the CEK machine
but need to be transformed into values when they become final states.