### PR TITLE
Drop syntactic list

### DIFF
--- a/simple-proofs/simple-symbolic.md
+++ b/simple-proofs/simple-symbolic.md
@@ -8,18 +8,22 @@ module SIMPLE-SYMBOLIC
   claim <k> [ [ (builtin addInteger) (con integer X)] (con integer Y)] =>
             < con integer Y +Int X > ... </k>
 
-  claim <k> [ (builtin _:IntegerBuiltinName) (con TN:TypeConstant _) ] => 
+  claim <k> [ (builtin _:IntegerBuiltinName) (con TN:TypeConstant _) ] =>
             (error) </k>
   requires TN =/=K integer
 
-  claim <k> [ [ (builtin _:IntegerBuiltinName) (con integer _) ] (con TN _ )] => 
+  claim <k> [ [ (builtin _:IntegerBuiltinName) (con integer _) ] (con TN _ )] =>
             (error) </k>
   requires TN =/=K integer
 
   claim <k> [ [ (builtin _:PolyBuiltinName) _:Term ]
                                             _:Term ] ~> T:Term =>
             (error) </k>
-  requires T =/=K Force 
+  requires T =/=K Force
+
+  // Removing the use of syntactic lists somehow makes this claim pass
+  claim <k> [ ( lam v_0 v_0 ) (T:Term) ] => T ~> [ < lam v_0 v_0 M > _] ... </k>
+        <env> M </env>
 
 endmodule
 ```

--- a/uplc-discharge.md
+++ b/uplc-discharge.md
@@ -48,8 +48,6 @@ module UPLC-DISCHARGE
   rule dischargeTerm([ T1:Term (T2:Term TL:TermList) ], RHO:Map) =>
        dischargeTermApp(TL, [dischargeTerm(T1, RHO) dischargeTerm(T2, RHO) ], RHO)
 
-  rule dischargeTermApp(.TermList, T, _) => T
-
   rule dischargeTermApp(T1:Term TL:TermList, T2:Term, RHO:Map) =>
   
        dischargeTermApp(TL, [T2 dischargeTerm(T1, RHO)], RHO)
@@ -59,5 +57,8 @@ module UPLC-DISCHARGE
   rule dischargeTerm((force T:Term), RHO:Map) => (force dischargeTerm(T, RHO))
   
   rule dischargeTerm((error), _) => (error)
+
+  rule dischargeTerm( T, .Map) => T
+
 endmodule
 ```

--- a/uplc-semantics.md
+++ b/uplc-semantics.md
@@ -32,9 +32,8 @@ module UPLC-SEMANTICS
 ```k
   syntax K ::= #app(Term, TermList, Map) [function]
   syntax K ::= #appAux(TermList, Map) [function]
-
   rule #app(M:Term, TL:TermList, RHO:Map) => M ~> #appAux(TL, RHO)
-  rule #appAux(N:Term .TermList, RHO) => [_ N RHO ]
+  rule #appAux(N:Term, RHO) => [_ N RHO ]
   rule #appAux(N:Term TL:TermList, RHO) => [_ N RHO ] ~> #appAux(TL, RHO) [owise]
 
 ```

--- a/uplc-syntax.md
+++ b/uplc-syntax.md
@@ -39,7 +39,8 @@ module UPLC-SYNTAX
                 | "(" "force" Term ")"
                 | "(" "error" ")"
 
-  syntax TermList ::= NeList{Term, ""}
+  syntax TermList ::= Term TermList
+                    | Term
 
   syntax Value ::= "<" "con" TypeConstant Constant ">"
                  | "<" "lam" UplcId Term Map ">"


### PR DESCRIPTION
The use of syntactic lists results in stuck states on #appAux. Replacing
the use with its syntactic equivalent somehow makes some claims evaluate
further due to a possible bug in the haskell backend.