### PR TITLE
Add symbolic MAP

### DIFF
--- a/uplc-environment.md
+++ b/uplc-environment.md
@@ -4,11 +4,24 @@
 require "domains.md"
 require "uplc-syntax.md"
 
+module UPLC-MAP-CONCRETE [concrete]
+  imports MAP
+endmodule
+
+module UPLC-MAP-SYMBOLIC [symbolic]
+  imports MAP-SYMBOLIC
+endmodule
+
+module UPLC-MAP
+  imports UPLC-MAP-CONCRETE
+  imports UPLC-MAP-SYMBOLIC
+endmodule
+
 module UPLC-ENVIRONMENT
   imports UPLC-ID
   imports BOOL-SYNTAX
   imports INT-SYNTAX
-  imports MAP
+  imports UPLC-MAP
   imports LIST
 
   syntax Bool ::= #in(Map, UplcId) [function, functional]

--- a/uplc-hash.md
+++ b/uplc-hash.md
@@ -10,7 +10,7 @@ requires "domains.md"
 requires "uplc-syntax.md"
 requires "krypto.md"
 
-module UPLC-HASH
+module UPLC-HASH-CONCRETE [concrete]
   imports INT
   imports STRING
   imports KRYPTO
@@ -19,5 +19,20 @@ module UPLC-HASH
 
   syntax Int ::= #uplcHash(Value) [function]
   rule #uplcHash(V:Value) => String2Base(Sha3_256(#unparseKORE(V)), 16)
+endmodule
+
+module UPLC-HASH-SYMBOLIC [symbolic]
+  imports INT
+  imports STRING
+  imports K-EQUAL
+  imports UPLC-SYNTAX
+
+  syntax Int ::= #uplcHash(Value) [function]
+  rule #uplcHash(V1:Value) ==Int #uplcHash(V2:Value) => V1 =/=K V2 [simplification]
+endmodule
+
+module UPLC-HASH
+  imports UPLC-HASH-CONCRETE
+  imports UPLC-HASH-SYMBOLIC
 endmodule
 ```


### PR DESCRIPTION
- Kplc prover does not need work on a concrete `MAP` but rather a symbolic one.

- This commit updates `UPLC-ENVIRONMENT` to include `MAP-SYMBOLIC`
  whenver the symbolic backend is used.