### PR TITLE
Prove simple identity claim with concrete inputs

### DIFF
--- a/simple-proofs/simple-symbolic.md
+++ b/simple-proofs/simple-symbolic.md
@@ -20,10 +20,27 @@ module SIMPLE-SYMBOLIC
                                             _:Term ] ~> T:Term =>
             (error) </k>
   requires T =/=K Force
+```
+ Removing the use of syntactic lists somehow makes this claim pass
 
-  // Removing the use of syntactic lists somehow makes this claim pass
+```k
   claim <k> [ ( lam v_0 v_0 ) (T:Term) ] => T ~> [ < lam v_0 v_0 M > _] ... </k>
         <env> M </env>
+```
+
+The following two claims proves that the constant 1 applied to the identity function returns the
+constant integer 1.
+
+```k
+  claim <k> [ ( lam v_0 v_0 ) (con integer 1) ] => < con integer 1 > ... </k>
+        <env> RHO => ?_RHO </env>
+        <heap> _ => ?_ </heap>
+  requires allValuesAreList(RHO) andBool (v_0 in_keys(RHO))
+
+  claim <k> [ ( lam v_0 v_0 ) (con integer 1) ] => < con integer 1 > ... </k>
+        <env> RHO => ?_RHO </env>
+        <heap> _ => ?_ </heap>
+  requires allValuesAreList(RHO) andBool notBool(v_0 in_keys(RHO))
 
 endmodule
 ```

--- a/simple-proofs/verification.k
+++ b/simple-proofs/verification.k
@@ -5,9 +5,12 @@ module VERIFICATION
   imports UPLC
   imports BYTES
 
-  syntax KItem ::= simplify(KItem)
-                 | simplified(KItem)
-
-  rule <k> simplify(K) => simplified(K) ... </k>
+  /*
+   * These rules are needed to establish that each element of map is a list so that the prover understands that the map
+   * that we use only contain lists
+   */
+  syntax Bool ::= allValuesAreList(Map) [function]
+  rule allValuesAreList(.Map) => true
+  rule allValuesAreList( _ |-> V M:Map ) => isList(V) andBool allValuesAreList(M)
 
 endmodule

--- a/simple-proofs/verification.k
+++ b/simple-proofs/verification.k
@@ -5,6 +5,22 @@ module VERIFICATION
   imports UPLC
   imports BYTES
 
+  rule (_:List ListItem(X:KItem))[-1] => X [simplification]
+
+  rule isList(M:Map[ _K:KItem ] orDefault .List) => true
+  requires allValuesAreList(M) [simplification]
+
+  rule #Ceil({@L:KItem}:>List) => {isList(@L) #Equals true} #And #Ceil(@L) [anywhere, simplification]
+
+  rule #Ceil(#push(@E:Map, @X:UplcId, @I:Int)) =>
+       ({@X in_keys(@E) #Equals false} #Or {isList(@E[@X] orDefault .List) #Equals true})
+       #And #Ceil(@E) #And #Ceil(@X) #And #Ceil(@I) [simplification]
+
+  rule {#uplcHash(V1:Value) #Equals #uplcHash(V2:Value)} => {V1 #Equals V2} [simplification]
+
+  rule M:Map[K:KItem] orDefault V:KItem => V
+  requires notBool(K in_keys(M)) [simplification]
+
   /*
    * These rules are needed to establish that each element of map is a list so that the prover understands that the map
    * that we use only contain lists

--- a/uplc-environment.md
+++ b/uplc-environment.md
@@ -4,22 +4,34 @@
 require "domains.md"
 require "uplc-syntax.md"
 
+module UPLC-MAP
+  imports MAP
+  imports MAP-SYMBOLIC
+endmodule
+
 module UPLC-ENVIRONMENT
   imports UPLC-ID
-  imports BOOL-SYNTAX
+  imports BOOL
   imports INT-SYNTAX
-  imports MAP
+  imports UPLC-MAP
   imports LIST
+  imports K-EQUAL
 
-  syntax Bool ::= #in(Map, UplcId) [function, functional]
-  rule #in(E:Map, X:UplcId) => X in_keys(E)
-  
+  syntax List ::= #append(List, Int) [function, functional]
+  rule #append(L:List, I:Int) => L ListItem(I)
+
+  syntax Int ::= #last(List) [function]
+  rule #last(L:List) => {L[-1]}:>Int
+
   syntax Value ::= #lookup(Map, UplcId, Map) [function]
-  rule #lookup((_ X:UplcId |-> _ ListItem(I:Int)), X, H:Map) => {H[I]}:>Value
-
-  syntax Map ::= #push(Map, UplcId, Int) [function, functional]
-  rule #push(E:Map, X:UplcId, I:Int) => E[X <- ({E[X]}:>List ListItem(I))]
+  rule #lookup(E:Map, X:UplcId, H:Map) => {H[#last({E[X]}:>List)]}:>Value
   requires X in_keys(E)
-  rule #push(E:Map, X:UplcId, I:Int) => E[X <- ListItem(I)] [owise]
+
+  syntax Map ::= #push(Map, UplcId, Int) [function]
+  rule #push(E:Map, X:UplcId, I:Int) =>
+       #if X in_keys(E)
+       #then E[X <- #append({E[X] orDefault .List}:>List, I)]
+       #else E[X <- ListItem(I)]
+       #fi
 endmodule
 ```

--- a/uplc-hash.md
+++ b/uplc-hash.md
@@ -1,16 +1,24 @@
 # UPLC Hash
 
-Caveat: this function is a potential bottleneck. A faster hashing
-scheme will be loocked at, because serializing to Kore is an extra
-process call, and calling `Sha3_256` also takes time. The LLVM
-backend already natively is computing hashes of things, and can do
-that directly if that functionality can be exposed.
 ```k
 requires "domains.md"
 requires "uplc-syntax.md"
 requires "krypto.md"
 
 module UPLC-HASH
+  imports UPLC-HASH-CONCRETE
+  imports UPLC-HASH-SYMBOLIC
+endmodule
+```
+
+Caveat: this function is a potential bottleneck. A faster hashing
+scheme will be loocked at, because serializing to Kore is an extra
+process call, and calling `Sha3_256` also takes time. The LLVM
+backend already natively is computing hashes of things, and can do
+that directly if that functionality can be exposed.
+
+```k
+module UPLC-HASH-CONCRETE [concrete]
   imports INT
   imports STRING
   imports KRYPTO
@@ -19,5 +27,19 @@ module UPLC-HASH
 
   syntax Int ::= #uplcHash(Value) [function]
   rule #uplcHash(V:Value) => String2Base(Sha3_256(#unparseKORE(V)), 16)
+endmodule
+```
+Symbolic hash function:
+
+A symbolic hash function does not need to generate a unique ID because this is simply used as a unique key value in a
+map. Instead of evaluating the actual hash, the K term `#uplcHash(Value)` itself can represent the key in the map.
+```k
+module UPLC-HASH-SYMBOLIC [symbolic]
+  imports INT
+  imports STRING
+  imports UPLC-SYNTAX
+  imports K-EQUAL
+
+  syntax Int ::= #uplcHash(Value) [function, functional, no-evaluators]
 endmodule
 ```

--- a/uplc-semantics.md
+++ b/uplc-semantics.md
@@ -46,11 +46,11 @@ module UPLC-SEMANTICS
   rule <k> X:UplcId => #lookup(RHO, X, Heap) ... </k>
        <env> RHO </env>
        <heap> Heap </heap>
-  requires #in(RHO, X)
+  requires X in_keys(RHO)
 
   rule <k> X:UplcId => (error) ... </k>
        <env> RHO </env>
-  requires notBool(#in(RHO, X))
+  requires notBool(X in_keys(RHO))
 
   rule <k> (con T:TypeConstant C:Constant) =>
            < con T:TypeConstant C:Constant > ... </k>


### PR DESCRIPTION
This PR adds a simple claim for identity function applied to the constant `(con integer 1)`. In order prove this claim, several modifications to existing functions and simplification rules were added to prove the claim.

Closes: https://github.com/runtimeverification/plutus-core-semantics/issues/220