### PR TITLE
Fix tailList semantics

### DIFF
--- a/tests/textual/new-syntax/tailList.uplc.expected
+++ b/tests/textual/new-syntax/tailList.uplc.expected
@@ -1,1 +1,1 @@
-      ( con integer [ 2 , 3 , ] ) 
+      ( con list ( integer ) [ 2 , 3 , ] ) 

--- a/tests/textual/new-syntax/tailList2.uplc.expected
+++ b/tests/textual/new-syntax/tailList2.uplc.expected
@@ -1,1 +1,1 @@
-      ( con integer [ ] ) 
+      ( con list ( integer ) [ ] ) 

--- a/uplc-polymorphic-builtins.md
+++ b/uplc-polymorphic-builtins.md
@@ -175,11 +175,11 @@ return an error if `sndPair`'s argument is not a pair.
 
   rule <k> #eval(tailList,
               ListItem(< con list(T:TypeConstant) [ .ConstantList ] >)) =>
-           < con T [ .ConstantList ] > ... </k>
+           < con list(T) [ .ConstantList ] > ... </k>
 
   rule <k> #eval(tailList,
               ListItem(< con list(T:TypeConstant) [ _C:Constant , L:ConstantList ] >)) =>
-           < con T [ L ] > ... </k>
+           < con list(T) [ L ] > ... </k>
 ```
 
 ## `nullList`


### PR DESCRIPTION
The evaluation rule for `tailList` was missing the `list` type constant.
This change adds the list type constant to the result of this
evaluation.