### PR TITLE
Add list sum test and expected output

### DIFF
--- a/tests/textual/new-syntax/listSum.uplc
+++ b/tests/textual/new-syntax/listSum.uplc
@@ -1,0 +1,21 @@
+(program 1.0.0
+
+  [ (lam f [(lam x [f (lam y [x x y])]) (lam x [f (lam y [x x y])])])
+    (lam lstAdd
+      (lam lst (force [ (force (builtin ifThenElse))
+               [ (force (builtin nullList)) lst ]
+
+               ( delay (con integer 0) )
+
+               ( delay
+                 [ (builtin addInteger)
+                   [ (force (builtin headList)) lst ]
+                   [ lstAdd [ (force (builtin tailList)) lst ] ]
+                 ]
+               )
+             ])
+      )
+    )
+    (con list(integer) [ 5 , 6 ] )
+  ]
+)

--- a/tests/textual/new-syntax/listSum.uplc.expected
+++ b/tests/textual/new-syntax/listSum.uplc.expected
@@ -1,0 +1,1 @@
+      ( con integer 11 ) 


### PR DESCRIPTION
This test is an implementation of a function that adds all list
elements. It's possible to implement this function using several
different approaches such as y-combinator, tail recursion, and etc.
The y-combinator was used to impelement this function but it's possible
that tail recursion could be more efficient for proofs...

Closes: https://github.com/runtimeverification/plutus-core-semantics/issues/223