### PR TITLE
Maximum integer from list function

### DIFF
--- a/tests/textual/new-syntax/maxList.uplc
+++ b/tests/textual/new-syntax/maxList.uplc
@@ -1,0 +1,21 @@
+(program 1.0.0
+  [ (lam maxList [ maxList (con list(integer) [ 1, 2, 24, 6, 3, 12, 3, 18, 100, 4 ] ) ])
+    [ (lam f [(lam x [f (lam y [x x y])]) (lam x [f (lam y [x x y])])])
+      (lam max (lam l
+        (force [ (force (builtin chooseList)) l
+          (delay (con integer 0))
+          (delay [ (lam hd (lam maxtail
+                   [ (force (builtin ifThenElse))
+                     [ (builtin lessThanInteger) hd maxtail ]
+                     maxtail
+                     hd
+                   ]))
+                   [ (force (builtin headList)) l ]
+                   [ max [ (force (builtin tailList)) l ] ]
+                 ]
+          )
+        ])
+      ))
+    ]
+  ]
+)

--- a/tests/textual/new-syntax/maxList.uplc.expected
+++ b/tests/textual/new-syntax/maxList.uplc.expected
@@ -1,0 +1,1 @@
+      ( con integer 100 ) 

--- a/tests/textual/new-syntax/maxListTailRec.uplc
+++ b/tests/textual/new-syntax/maxListTailRec.uplc
@@ -1,0 +1,21 @@
+(program 1.0.0
+  [ (lam maxList [ maxList (con list(integer) [ 1, 2, 24, 6, 3, 12, 3, 18, 100, 4 ] ) ])
+    [ (lam maxListAux (lam l [ maxListAux l (con integer 0) ]))
+      [ (lam f [(lam x [f (lam y [x x y])]) (lam x [f (lam y [x x y])])])
+        (lam max (lam l (lam cont
+          (force [ (force (builtin chooseList))
+                   l
+          (delay   cont)
+          (delay   [ max
+                   [ (force (builtin tailList)) l ]
+                   [ (force (builtin ifThenElse))
+                     [ (builtin lessThanInteger) cont [ (force (builtin headList)) l ] ]
+                     [ (force (builtin headList)) l ]
+                     cont
+                   ]])
+          ])
+        )))
+      ]
+    ]
+  ]
+)

--- a/tests/textual/new-syntax/maxListTailRec.uplc.expected
+++ b/tests/textual/new-syntax/maxListTailRec.uplc.expected
@@ -1,0 +1,1 @@
+      ( con integer 100 ) 


### PR DESCRIPTION
fixes: #222 

Implemented are two variants, one is recursive, and the other is tail recursive.

The function makes two assumptions about the list that gets passed in to it:
- The list will be non-empty
- Each number in the list will be greater than or equal to 0