### PR TITLE
Add claims for recursive list sum function

### DIFF
--- a/simple-proofs/simple-symbolic.md
+++ b/simple-proofs/simple-symbolic.md
@@ -37,6 +37,22 @@ constant integer 1.
 ```k
   claim <k> [ ( lam v_0 v_0 ) (con integer 1) ] => < con integer 1 > ... </k>
         <env> _ => .Map </env>
+```
+
+Claims for List sum function
+
+```k
+claim <k>
+  [ FIXED_POINT LIST_SUM (con list(integer) [ .ConstantList ] ) ] => < con integer 0 > </k>
+        <env> .Map => ?_ </env>
+
+claim <k>
+  [ FIXED_POINT LIST_SUM (con list(integer) [ 2, 3, 5 ] ) ] => < con integer 10 > </k>
+        <env> .Map => ?_ </env>
+
+claim <k>
+  [ FIXED_POINT LIST_SUM ( con list(integer) [ X, Y ] ) ] => < con integer X +Int Y > </k>
+        <env> .Map => ?_ </env>
 
 endmodule
 ```

--- a/simple-proofs/verification.k
+++ b/simple-proofs/verification.k
@@ -8,4 +8,24 @@ module VERIFICATION
   rule M:Map[K:KItem] orDefault V:KItem => V
   requires notBool(K in_keys(M)) [simplification]
 
+  syntax Term ::= "FIXED_POINT" [macro]
+  rule FIXED_POINT => (lam f_0 [(lam x_0 [f_0 (lam y_0 [x_0 x_0 y_0])]) (lam x_1 [f_0 (lam y_1 [x_1 x_1 y_1])])])
+
+  syntax Term ::= "LIST_SUM" [macro]
+  rule LIST_SUM =>
+    (lam f_lstSum
+      (lam in_lst (force [ (force (builtin ifThenElse))
+               [ (force (builtin nullList)) in_lst ]
+
+               ( delay (con integer 0) )
+
+               ( delay
+                 [ (builtin addInteger)
+                   [ (force (builtin headList)) in_lst ]
+                   [ f_lstSum [ (force (builtin tailList)) in_lst ] ]
+                 ]
+               )
+             ])
+      )
+    )
 endmodule


### PR DESCRIPTION
These claims apply concrete and symbolic inputs to the listSum function. K macros are used to make the claims easier to read.