### PR TITLE
Make #push functional

### DIFF
--- a/simple-proofs/simple-symbolic.md
+++ b/simple-proofs/simple-symbolic.md
@@ -28,19 +28,14 @@ module SIMPLE-SYMBOLIC
         <env> M </env>
 ```
 
-The following two claims proves that the constant 1 applied to the identity function returns the
+The following claim proves that the constant 1 applied to the identity function returns the
 constant integer 1.
 
 ```k
   claim <k> [ ( lam v_0 v_0 ) (con integer 1) ] => < con integer 1 > ... </k>
         <env> RHO => ?_RHO </env>
         <heap> _ => ?_ </heap>
-  requires allValuesAreList(RHO) andBool (v_0 in_keys(RHO))
-
-  claim <k> [ ( lam v_0 v_0 ) (con integer 1) ] => < con integer 1 > ... </k>
-        <env> RHO => ?_RHO </env>
-        <heap> _ => ?_ </heap>
-  requires allValuesAreList(RHO) andBool notBool(v_0 in_keys(RHO))
+  requires allValuesAreList(RHO)
 
 endmodule
 ```

--- a/uplc-environment.md
+++ b/uplc-environment.md
@@ -17,9 +17,6 @@ module UPLC-ENVIRONMENT
   imports LIST
   imports K-EQUAL
 
-  syntax List ::= #append(List, Int) [function, functional]
-  rule #append(L:List, I:Int) => L ListItem(I)
-
   syntax Int ::= #last(List) [function]
   rule #last(L:List) => {L[-1]}:>Int
 
@@ -27,11 +24,8 @@ module UPLC-ENVIRONMENT
   rule #lookup(E:Map, X:UplcId, H:Map) => {H[#last({E[X]}:>List)]}:>Value
   requires X in_keys(E)
 
-  syntax Map ::= #push(Map, UplcId, Int) [function]
-  rule #push(E:Map, X:UplcId, I:Int) =>
-       #if X in_keys(E)
-       #then E[X <- #append({E[X] orDefault .List}:>List, I)]
-       #else E[X <- ListItem(I)]
-       #fi
+  syntax Map ::= #push(Map, UplcId, Int) [function, functional]
+  rule #push(E:Map, X:UplcId, I:Int) => E[X <- {E[X] orDefault .List}:>List ListItem(I)]
+
 endmodule
 ```


### PR DESCRIPTION
This PR changes `#push` to be functional and therefore simplifies the identity proof to a single claim.