### PR TITLE
Make push functional

### DIFF
--- a/simple-proofs/simple-symbolic.md
+++ b/simple-proofs/simple-symbolic.md
@@ -28,19 +28,13 @@ module SIMPLE-SYMBOLIC
         <env> M </env>
 ```
 
-The following two claims proves that the constant 1 applied to the identity function returns the
+The following claim proves that the constant 1 applied to the identity function returns the
 constant integer 1.
 
 ```k
   claim <k> [ ( lam v_0 v_0 ) (con integer 1) ] => < con integer 1 > ... </k>
-        <env> RHO => ?_RHO </env>
+        <env> _ => ?_ </env>
         <heap> _ => ?_ </heap>
-  requires allValuesAreList(RHO) andBool (v_0 in_keys(RHO))
-
-  claim <k> [ ( lam v_0 v_0 ) (con integer 1) ] => < con integer 1 > ... </k>
-        <env> RHO => ?_RHO </env>
-        <heap> _ => ?_ </heap>
-  requires allValuesAreList(RHO) andBool notBool(v_0 in_keys(RHO))
 
 endmodule
 ```

--- a/simple-proofs/verification.k
+++ b/simple-proofs/verification.k
@@ -6,9 +6,6 @@ module VERIFICATION
 
   rule (_:List ListItem(X:KItem))[-1] => X [simplification]
 
-  rule isList(M:Map[ _K:KItem ] orDefault .List) => true
-  requires allValuesAreList(M) [simplification]
-
   rule #Ceil({@L:KItem}:>List) => {isList(@L) #Equals true} #And #Ceil(@L) [anywhere, simplification]
 
   rule #Ceil(#push(@E:Env, @X:UplcId, @I:Int)) =>
@@ -19,13 +16,5 @@ module VERIFICATION
 
   rule M:Map[K:KItem] orDefault V:KItem => V
   requires notBool(K in_keys(M)) [simplification]
-
-  /*
-   * These rules are needed to establish that each element of map is a list so that the prover understands that the map
-   * that we use only contain lists
-   */
-  syntax Bool ::= allValuesAreList(Map) [function]
-  rule allValuesAreList(.Map) => true
-  rule allValuesAreList( _ |-> V M:Map ) => isList(V) andBool allValuesAreList(M)
 
 endmodule

--- a/simple-proofs/verification.k
+++ b/simple-proofs/verification.k
@@ -11,7 +11,7 @@ module VERIFICATION
 
   rule #Ceil({@L:KItem}:>List) => {isList(@L) #Equals true} #And #Ceil(@L) [anywhere, simplification]
 
-  rule #Ceil(#push(@E:Map, @X:UplcId, @I:Int)) =>
+  rule #Ceil(#push(@E:Env, @X:UplcId, @I:Int)) =>
        ({@X in_keys(@E) #Equals false} #Or {isList(@E[@X] orDefault .List) #Equals true})
        #And #Ceil(@E) #And #Ceil(@X) #And #Ceil(@I) [simplification]
 

--- a/simple-proofs/verification.k
+++ b/simple-proofs/verification.k
@@ -1,5 +1,4 @@
 requires "uplc.md"
-requires "domains.md"
 
 module VERIFICATION
   imports UPLC

--- a/uplc-configuration.md
+++ b/uplc-configuration.md
@@ -16,7 +16,7 @@ module UPLC-CONFIGURATION
   imports UPLC-ENVIRONMENT
 
   syntax Frame ::= "Force"
-                 | "[_" Term Map "]"
+                 | "[_" Term Env "]"
                  | "[" Value "_]"
 ```
 
@@ -49,7 +49,7 @@ is used to keep track of the data emitted by the `trace` builtin.
       Int2Bytes( lengthString( INPUT ) /Int 2, String2Base( INPUT, 16 ), BE)
 
   configuration <k> #handleProgram($PGM:Program) </k>
-                <env> .Map </env>
+                <env> .Env </env>
                 <heap> .Map </heap>
                 <trace> .List </trace>
 ```

--- a/uplc-discharge.md
+++ b/uplc-discharge.md
@@ -8,17 +8,17 @@ module UPLC-DISCHARGE
   imports LIST
   imports UPLC-SYNTAX
 
-  syntax Term ::= dischargeTerm(Term, Map) [function]
-  syntax Term ::= dischargeTermApp(TermList, Term, Map) [function]
+  syntax Term ::= dischargeTerm(Term, Env) [function]
+  syntax Term ::= dischargeTermApp(TermList, Term, Env) [function]
   syntax Term ::= discharge(Value) [function]
   syntax Term ::= dischargeApp(BuiltinName, List) [function]
   syntax Term ::= dischargeAppAux(Term, List) [function]
   
-  rule discharge(< con T:TypeConstant C:Constant >) => (con T C)  
+  rule discharge(< con T:TypeConstant C:Constant >) => (con T C)
 
-  rule discharge(< lam I:UplcId T:Term RHO:Map >) => (lam I dischargeTerm(T, RHO)) 
+  rule discharge(< lam I:UplcId T:Term RHO:Env >) => (lam I dischargeTerm(T, RHO))
 
-  rule discharge(< delay T:Term RHO:Map >) => (delay dischargeTerm(T, RHO)) 
+  rule discharge(< delay T:Term RHO:Env >) => (delay dischargeTerm(T, RHO))
 
   rule discharge(< builtin BN:BuiltinName L:List _ >) =>
        dischargeApp(BN, L)
@@ -34,7 +34,7 @@ module UPLC-DISCHARGE
        dischargeAppAux([T discharge(V)], L)
 
   rule dischargeTerm(X:UplcId, RHO) => discharge({RHO[X]}:>Value)
-  requires X in_keys(RHO) 
+  requires X in_keys(RHO)
   
   rule dischargeTerm(X:UplcId, RHO) => X
   requires notBool(X in_keys(RHO))
@@ -43,22 +43,21 @@ module UPLC-DISCHARGE
 
   rule dischargeTerm((builtin BN:BuiltinName), _) => (builtin BN)
 
-  rule dischargeTerm((lam X:UplcId T:Term), RHO:Map) => (lam X dischargeTerm(T, RHO))
+  rule dischargeTerm((lam X:UplcId T:Term), RHO:Env) => (lam X dischargeTerm(T, RHO))
 
-  rule dischargeTerm([ T1:Term (T2:Term TL:TermList) ], RHO:Map) =>
+  rule dischargeTerm([ T1:Term (T2:Term TL:TermList) ], RHO:Env) =>
        dischargeTermApp(TL, [dischargeTerm(T1, RHO) dischargeTerm(T2, RHO) ], RHO)
 
-  rule dischargeTermApp(T1:Term TL:TermList, T2:Term, RHO:Map) =>
-  
+  rule dischargeTermApp(T1:Term TL:TermList, T2:Term, RHO:Env) =>
        dischargeTermApp(TL, [T2 dischargeTerm(T1, RHO)], RHO)
 
-  rule dischargeTerm((delay T:Term), RHO:Map) => (delay dischargeTerm(T, RHO))
+  rule dischargeTerm((delay T:Term), RHO:Env) => (delay dischargeTerm(T, RHO))
 
-  rule dischargeTerm((force T:Term), RHO:Map) => (force dischargeTerm(T, RHO))
+  rule dischargeTerm((force T:Term), RHO:Env) => (force dischargeTerm(T, RHO))
   
   rule dischargeTerm((error), _) => (error)
 
-  rule dischargeTerm( T, .Map) => T
+  rule dischargeTerm( T, .Env) => T
 
 endmodule
 ```

--- a/uplc-environment.md
+++ b/uplc-environment.md
@@ -1,7 +1,6 @@
 # UPLC Environment
 
 ```k
-require "domains.md"
 require "uplc-syntax.md"
 
 module UPLC-MAP

--- a/uplc-environment.md
+++ b/uplc-environment.md
@@ -17,9 +17,6 @@ module UPLC-ENVIRONMENT
   imports LIST
   imports K-EQUAL
 
-  syntax List ::= #append(List, Int) [function, functional]
-  rule #append(L:List, I:Int) => L ListItem(I)
-
   syntax Int ::= #last(List) [function]
   rule #last(L:List) => {L[-1]}:>Int
 
@@ -27,11 +24,8 @@ module UPLC-ENVIRONMENT
   rule #lookup(E:Map, X:UplcId, H:Map) => {H[#last({E[X]}:>List)]}:>Value
   requires X in_keys(E)
 
-  syntax Map ::= #push(Map, UplcId, Int) [function]
-  rule #push(E:Map, X:UplcId, I:Int) =>
-       #if X in_keys(E)
-       #then E[X <- #append({E[X] orDefault .List}:>List, I)]
-       #else E[X <- ListItem(I)]
-       #fi
+  syntax Map ::= #push(Map, UplcId, Int) [function, functional]
+  rule #push(E:Map, X:UplcId, I:Int) => E[X <- {E[X] orDefault .List}:>List ListItem(I)]
+
 endmodule
 ```

--- a/uplc-environment.md
+++ b/uplc-environment.md
@@ -3,28 +3,165 @@
 ```k
 require "uplc-syntax.md"
 
-module UPLC-MAP
-  imports MAP
-  imports MAP-SYMBOLIC
-endmodule
-
 module UPLC-ENVIRONMENT
-  imports UPLC-ID
-  imports BOOL
-  imports INT-SYNTAX
-  imports UPLC-MAP
-  imports LIST
-  imports K-EQUAL
+  imports ENV-CONCRETE
+  imports ENV-SYMBOLIC
+  imports MAP-SYMBOLIC
+  imports MAP
+  imports INT
 
   syntax Int ::= #last(List) [function]
   rule #last(L:List) => {L[-1]}:>Int
 
-  syntax Value ::= #lookup(Map, UplcId, Map) [function]
-  rule #lookup(E:Map, X:UplcId, H:Map) => {H[#last({E[X]}:>List)]}:>Value
+  syntax Value ::= #lookup(Env, UplcId, Map) [function]
+  rule #lookup(E:Env, X:UplcId, H:Map) => {H[#last({E[X]}:>List)]}:>Value
   requires X in_keys(E)
 
-  syntax Map ::= #push(Map, UplcId, Int) [function, functional]
-  rule #push(E:Map, X:UplcId, I:Int) => E[X <- {E[X] orDefault .List}:>List ListItem(I)]
+endmodule
+
+module ENV-CONCRETE [concrete]
+  imports INT
+  imports LIST
+  imports UPLC-ID
+  imports MAP
+
+  syntax Env ::= Map
+  syntax Map ::= ".Env" [macro]
+  rule .Env => .Map
+
+  syntax Map ::= #push(Env, UplcId, Int) [function]
+  rule #push(E:Env, X:UplcId, I:Int) => {E}:>Map[X <- {{E}:>Map[X] orDefault .List}:>List ListItem(I)]
+
+endmodule
+
+```
+
+The Symbolic implementation of Env - a map where keys are UplcId's and the values are lists. Using this implementation makes `#push`
+functional. A regular Map would require a cast to List which can result in bottom.
+
+```k
+
+module ENV-SYMBOLIC [symbolic]
+  imports INT
+  imports STRING
+  imports LIST
+  imports SET
+  imports UPLC-ID
+  imports private K-EQUAL
+  imports private BOOL
+
+  syntax Env ::= #push(Env, UplcId, Int) [function, functional]
+  rule #push(E:Env, X:UplcId, I:Int) => E[X <- (E[X] orDefault .List) ListItem(I)]
+
+```
+
+The following definitions are boilerplate Map functions from domains.md.
+
+```k
+
+  syntax Env [hook(MAP.Map)]
+
+  syntax Env ::= Env Env
+      [ left, function, hook(MAP.concat), klabel(_Env_), symbol, assoc, comm
+      , unit(.Env), element(_|->Env_), index(0), format(%1%n%2)
+      ]
+
+  syntax Env ::= ".Env"
+      [ function, functional, hook(MAP.unit), klabel(.Env), symbol
+      , latex(\dotCt{Env})
+      ]
+
+  syntax Env ::= UplcId "|->" List
+      [ function, functional, hook(MAP.element), klabel(_|->Env_), symbol
+      , latex({#1}\mapsto{#2})
+      ]
+
+  syntax priorities _|->Env_ > _Env_ .Env
+
+  syntax non-assoc _|->Env_
+
+  syntax List ::= Env "[" UplcId "]"
+      [function, hook(MAP.lookup), klabel(Env:lookup), symbol]
+
+  syntax List ::= Env "[" UplcId "]" "orDefault" List [function, functional, hook(MAP.lookupOrDefault), klabel(Env:lookupOrDefault)]
+
+  syntax Env ::= Env "[" UplcId "<-" value:List "]" [function, functional, klabel(Env:update), symbol, hook(MAP.update), prefer]
+
+  syntax Env ::= Env "[" UplcId "<-" "undef" "]" [function, functional, hook(MAP.remove), klabel(Env:removeEntryEnv), symbol]
+
+  syntax Env ::= Env "-Env" Env
+      [function, functional, hook(MAP.difference), latex({#1}-_{\it Env}{#2}), klabel(_-Env_)]
+
+  syntax Env ::= updateEnv(Env, Env) [function, functional, hook(MAP.updateAll), klabel(Env:updateAll)]
+
+  syntax Env ::= removeAll(Env, Set) [function, functional, hook(MAP.removeAll), klabel(Env:removeAll)]
+
+  syntax Set ::= keys(Env) [function, functional, hook(MAP.keys), klabel(Env:keys)]
+
+  syntax List ::= "keys_list" "(" Env ")" [function, hook(MAP.keys_list), klabel(Env:keys_list)]
+
+  syntax Bool ::= UplcId "in_keys" "(" Env ")" [function, functional, hook(MAP.in_keys), klabel(Env:in_keys)]
+
+  syntax List ::= values(Env) [function, hook(MAP.values), klabel(Env:values)]
+
+  syntax Int ::= size(Env) [function, functional, hook(MAP.size), klabel(Env:size)]
+
+  syntax Bool ::= Env "<=Env" Env
+      [function, functional, hook(MAP.inclusion), klabel(Env:_<=Env_)]
+
+  syntax KItem ::= choice(Env) [function, hook(MAP.choice), klabel(Env:choice)]
+```
+
+The following simplification rules are lifted from the MAP-SYMBOLIC module from domains.md.
+
+```k
+
+  rule #Ceil(@E:Env [@U:UplcId]) => {(@U in_keys(@E)) #Equals true} #And #Ceil(@E) #And #Ceil(@U) [anywhere, simplification]
+
+  // Symbolic update
+
+  // Adding the definedness condition `notBool (K in_keys(E))` in the ensures clause of the following rule would be redundant
+  // because K also appears in the rhs, preserving the case when it's #Bottom.
+  rule (K |-> _ E:Env) [ K <- V ] => (K |-> V E) [simplification]
+  rule E:Env [ K <- V ] => (K |-> V E) requires notBool (K in_keys(E)) [simplification]
+  rule E:Env [ K <- _ ] [ K <- V ] => E [ K <- V ] [simplification]
+  // Adding the definedness condition `notBool (K1 in_keys(E))` in the ensures clause of the following rule would be redundant
+  // because K1 also appears in the rhs, preserving the case when it's #Bottom.
+  rule (K1 |-> V1 E:Env) [ K2 <- V2 ] => (K1 |-> V1 (E [ K2 <- V2 ])) requires K1 =/=K K2 [simplification]
+
+  // Symbolic remove
+  rule (K |-> _ E:Env) [ K <- undef ] => E ensures notBool (K in_keys(E)) [simplification]
+  rule E:Env [ K <- undef ] => E requires notBool (K in_keys(E)) [simplification]
+  // Adding the definedness condition `notBool (K1 in_keys(E))` in the ensures clause of the following rule would be redundant
+  // because K1 also appears in the rhs, preserving the case when it's #Bottom.
+  rule (K1 |-> V1 E:Env) [ K2 <- undef ] => (K1 |-> V1 (E [ K2 <- undef ])) requires K1 =/=K K2 [simplification]
+
+  // Symbolic lookup
+  rule (K  |->  V E:Env) [ K ]  => V ensures notBool (K in_keys(E)) [simplification]
+  rule (K1 |-> _V E:Env) [ K2 ] => E [K2] requires K1 =/=K K2 ensures notBool (K1 in_keys(E)) [simplification]
+  rule (_E:Env [ K  <-  V1 ]) [ K ]  => V1 [simplification]
+  rule ( E:Env [ K1 <- _V1 ]) [ K2 ] => E [ K2 ] requires K1 =/=K K2 [simplification]
+
+  // Symbolic in_keys
+  rule K in_keys(_E [ K <- undef ]) => false [simplification]
+  rule K in_keys(_E [ K <- _ ]) => true [simplification]
+  rule K1 in_keys(E [ K2 <- _ ]) => true requires K1 ==K K2 orBool K1 in_keys(E) [simplification]
+  rule K1 in_keys(E [ K2 <- _ ]) => K1 in_keys(E) requires K1 =/=K K2 [simplification]
+
+/*
+// The rule below is automatically generated by the frontend for every sort
+// hooked to MAP.Map. It is left here to serve as documentation.
+
+  rule #Ceil(@M:Map (@K:KItem |-> @V:KItem)) => {(@K in_keys(@M)) #Equals false} #And #Ceil(@M) #And #Ceil(@K) #And #Ceil(@V)
+    [anywhere, simplification]
+*/
+```
+
+the above comment seems like a useful rule: this is the implementation for Env with the approperiate types.
+
+```k
+  rule #Ceil(@E:Env (@U:UplcId |-> @L:List)) => {(@U in_keys(@E)) #Equals false} #And #Ceil(@E) #And #Ceil(@U) #And #Ceil(@L)
+    [anywhere, simplification]
 
 endmodule
 ```

--- a/uplc-semantics.md
+++ b/uplc-semantics.md
@@ -30,11 +30,11 @@ module UPLC-SEMANTICS
 ## Non-interactive application
 
 ```k
-  syntax K ::= #app(Term, TermList, Map) [function]
-  syntax K ::= #appAux(TermList, Map) [function]
-  rule #app(M:Term, TL:TermList, RHO:Map) => M ~> #appAux(TL, RHO)
-  rule #appAux(N:Term, RHO) => [_ N RHO ]
-  rule #appAux(N:Term TL:TermList, RHO) => [_ N RHO ] ~> #appAux(TL, RHO) [owise]
+  syntax K ::= #app(Term, TermList, Env) [function]
+  syntax K ::= #appAux(TermList, Env) [function]
+  rule #app(M:Term, TL:TermList, RHO:Env) => M ~> #appAux(TL, RHO)
+  rule #appAux(N:Term, RHO:Env) => [_ N RHO ]
+  rule #appAux(N:Term TL:TermList, RHO:Env) => [_ N RHO ] ~> #appAux(TL, RHO) [owise]
 
 ```
 
@@ -56,23 +56,23 @@ module UPLC-SEMANTICS
            < con T:TypeConstant C:Constant > ... </k>
 
   rule <k> (lam X:UplcId M:Term) => < lam X M RHO > ... </k>
-       <env> RHO:Map </env>
+       <env> RHO </env>
 
   rule <k> (delay M:Term) => < delay M RHO > ... </k>
-       <env> RHO:Map </env>
+       <env> RHO </env>
 
   rule <k> (force M:Term) => (M ~> Force) ... </k>
 
-  rule <k> < delay M:Term RHO:Map > ~> Force => M ... </k>
-       <env> _ => RHO:Map </env>
-
-  rule <k> [ M:Term TL:TermList ] => #app(M, TL, RHO) ... </k>
-       <env> RHO:Map </env>
-
-  rule <k> V:Value ~> [_ M RHO:Map ] => M ~> [ V _] ... </k>
+  rule <k> < delay M:Term RHO > ~> Force => M ... </k>
        <env> _ => RHO </env>
 
-  rule <k> V:Value ~> [ < lam X:UplcId M:Term RHO:Map > _] => M ... </k>
+  rule <k> [ M:Term TL:TermList ] => #app(M, TL, RHO) ... </k>
+       <env> RHO </env>
+
+  rule <k> V:Value ~> [_ M RHO ] => M ~> [ V _] ... </k>
+       <env> _ => RHO </env>
+
+  rule <k> V:Value ~> [ < lam X:UplcId M:Term RHO:Env > _] => M ... </k>
        <env> _ => #push( RHO, X, #uplcHash(V) ) </env>
        <heap> Heap => Heap[ #uplcHash(V) <- V ] </heap>
 

--- a/uplc-syntax.md
+++ b/uplc-syntax.md
@@ -43,9 +43,10 @@ module UPLC-SYNTAX
                     | Term
 
   syntax Value ::= "<" "con" TypeConstant Constant ">"
-                 | "<" "lam" UplcId Term Map ">"
-                 | "<" "delay" Term Map ">"
+                 | "<" "lam" UplcId Term Env ">"
+                 | "<" "delay" Term Env ">"
                  | "<" "builtin" BuiltinName List Int ">"
+                 | "ErrorValue"
 
   syntax TypeConstant ::= "integer"
                         | "data"


### PR DESCRIPTION
This (rather large) pull request adds a typed map called Env which makes it possible to define #push as a total function. As a result, we can reduce the identity claim to a single claim with a generalized environment and no requires clauses!