### PR TITLE
Clean env on return phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 **/#*
 *.sh
 unit-tests/verification/
+simple-proofs/verification/
 *.swo
 *.swn
 *.swp

--- a/simple-proofs/simple-symbolic.md
+++ b/simple-proofs/simple-symbolic.md
@@ -7,13 +7,16 @@ module SIMPLE-SYMBOLIC
 
   claim <k> [ [ (builtin addInteger) (con integer X)] (con integer Y)] =>
             < con integer Y +Int X > ... </k>
+        <env> _ => .Map </env>
 
   claim <k> [ (builtin _:IntegerBuiltinName) (con TN:TypeConstant _) ] =>
             (error) </k>
+        <env> _ => .Map </env>
   requires TN =/=K integer
 
   claim <k> [ [ (builtin _:IntegerBuiltinName) (con integer _) ] (con TN _ )] =>
             (error) </k>
+        <env> _ => .Map </env>
   requires TN =/=K integer
 
   claim <k> [ [ (builtin _:PolyBuiltinName) _:Term ]
@@ -33,7 +36,7 @@ constant integer 1.
 
 ```k
   claim <k> [ ( lam v_0 v_0 ) (con integer 1) ] => < con integer 1 > ... </k>
-        <env> _ => ?_ </env>
+        <env> _ => .Map </env>
 
 endmodule
 ```

--- a/uplc-bytestring-builtins.md
+++ b/uplc-bytestring-builtins.md
@@ -22,6 +22,7 @@ module UPLC-BYTESTRING-BUILTINS
                   appendByteString, 2) => true
 
   rule <k> (builtin appendByteString) => < builtin appendByteString .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(appendByteString,
                      (ListItem(< con bytestring B1:ByteString >)
@@ -40,6 +41,7 @@ module UPLC-BYTESTRING-BUILTINS
                   ListItem(< con bytestring _ >), consByteString, 2) => true
 
   rule <k> (builtin consByteString) => < builtin consByteString .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(consByteString,
                      (ListItem(< con integer I:Int >)
@@ -62,6 +64,7 @@ module UPLC-BYTESTRING-BUILTINS
                   ListItem(< con bytestring _ >), sliceByteString, 3) => true
 
   rule <k> (builtin sliceByteString) => < builtin sliceByteString .List 3 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(sliceByteString,
                     (ListItem(< con integer I1:Int >)
@@ -78,6 +81,7 @@ module UPLC-BYTESTRING-BUILTINS
   rule #typeCheck(ListItem(< con bytestring _ >), lengthOfByteString, 1) => true
 
   rule <k> (builtin lengthOfByteString) => < builtin lengthOfByteString .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(lengthOfByteString,
                      ListItem(< con bytestring B:ByteString >)) =>
@@ -95,6 +99,7 @@ module UPLC-BYTESTRING-BUILTINS
                   ListItem(< con integer _ >), indexByteString, 2) => true
                   
   rule <k> (builtin indexByteString) => < builtin indexByteString .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(indexByteString,
                      (ListItem(< con bytestring B:ByteString >)
@@ -113,6 +118,7 @@ module UPLC-BYTESTRING-BUILTINS
   rule #typeCheck(ListItem(< con bytestring _ >)ListItem(< con bytestring _ >), equalsByteString, 2) => true
 
   rule <k> (builtin equalsByteString) => < builtin equalsByteString .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(equalsByteString,
                      (ListItem(< con bytestring B1:ByteString >)
@@ -137,6 +143,7 @@ module UPLC-BYTESTRING-BUILTINS
   rule #typeCheck(ListItem(< con bytestring _ >)ListItem(< con bytestring _ >), lessThanByteString, 2) => true
 
   rule <k> (builtin lessThanByteString) => < builtin lessThanByteString .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(lessThanByteString,
                      (ListItem(< con bytestring B1:ByteString >)
@@ -160,8 +167,8 @@ module UPLC-BYTESTRING-BUILTINS
 
   rule #typeCheck(ListItem(< con bytestring _ >)ListItem(< con bytestring _ >), lessThanEqualsByteString, 2) => true
 
-  rule <k> (builtin lessThanEqualsByteString) =>
-            < builtin lessThanEqualsByteString .List 2 > ... </k>
+  rule <k> (builtin lessThanEqualsByteString) => < builtin lessThanEqualsByteString .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(lessThanEqualsByteString,
                      (ListItem(< con bytestring B1:ByteString >)

--- a/uplc-crypto-builtins.md
+++ b/uplc-crypto-builtins.md
@@ -75,6 +75,7 @@ a ByteString.
   rule #typeCheck(ListItem(< con bytestring _ >), sha3_256, 1) => true
 
   rule <k> (builtin sha3_256) => < builtin sha3_256 .List 1 >  ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(sha3_256, ListItem(< con bytestring B:ByteString >)) =>
            < con bytestring unTrimByteString(Sha3_256Wrapper(encode(B))) > ... </k>
@@ -90,6 +91,7 @@ The same steps of `sha3_256` are taken to produce the proper string argument for
   rule #typeCheck(ListItem(< con bytestring _ >), sha2_256, 1) => true
 
   rule <k> (builtin sha2_256) => < builtin sha2_256 .List 1 >  ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(sha2_256, ListItem(< con bytestring B:ByteString >)) =>
            < con bytestring unTrimByteString(Sha256Wrapper(encode(B))) > ... </k>
@@ -105,6 +107,7 @@ The same steps of `sha3_256` are taken to produce the proper string argument for
   rule #typeCheck(ListItem(< con bytestring _ >), blake2b_256, 1) => true
 
   rule <k> (builtin blake2b_256) => < builtin blake2b_256 .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(blake2b_256, ListItem(< con bytestring B:ByteString >)) =>
            < con bytestring unTrimByteString(Blake2b256Wrapper(encode(B))) > ... </k>
@@ -122,6 +125,7 @@ The same steps of `sha3_256` are taken to produce the proper string argument for
   rule #typeCheck(ListItem(< con bytestring _ >)ListItem(< con bytestring _ >)ListItem(< con bytestring _ >), verifySignature, 3) => true
 
   rule <k> (builtin verifySignature) => < builtin verifySignature .List 3 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(verifySignature,
                  (ListItem(< con bytestring K:ByteString >)

--- a/uplc-data-builtins.md
+++ b/uplc-data-builtins.md
@@ -45,6 +45,7 @@ module UPLC-DATA-BUILTINS
   rule #typeCheck(ListItem(< con data{ _ } >)ListItem( _:Value )ListItem( _:Value )ListItem( _:Value )ListItem( _:Value )ListItem( _:Value ), chooseData, 6) => true
   
   rule <k> (builtin chooseData) ~> Force => < builtin chooseData .List 6 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(chooseData,
                      (ListItem(< con data { Constr _Ii:Int [ _DL:DataList ] } >)
@@ -97,6 +98,7 @@ module UPLC-DATA-BUILTINS
   rule #typeCheck(ListItem(< con integer _ >)ListItem(< con list(data)[ _ ] >), constrData, 2) => true
 
   rule <k> (builtin constrData) => < builtin constrData .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(constrData,
                  (ListItem(< con integer I:Int >)
@@ -112,6 +114,7 @@ module UPLC-DATA-BUILTINS
   rule #typeCheck(ListItem(< con list(pair(data)(data))[ _ ] >), mapData, 1) => true
 
   rule <k> (builtin mapData) => < builtin mapData .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(mapData,
                  ListItem(< con list(pair(data)(data)) [ L:ConstantList ] >)) =>
@@ -126,6 +129,7 @@ module UPLC-DATA-BUILTINS
   rule #typeCheck(ListItem(< con list(data)[ _ ] >), listData, 1) => true
 
   rule <k> (builtin listData) => < builtin listData .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(listData,
                  ListItem(< con list(data) [ L:ConstantList ] >)) =>
@@ -140,6 +144,7 @@ module UPLC-DATA-BUILTINS
   rule #typeCheck(ListItem(< con integer _ >), iData, 1) => true
 
   rule <k> (builtin iData) => < builtin iData .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(iData,
                  ListItem(< con integer I:Int >)) =>
@@ -154,6 +159,7 @@ module UPLC-DATA-BUILTINS
   rule #typeCheck(ListItem(< con bytestring _ >), bData, 1) => true
 
   rule <k> (builtin bData) => < builtin bData .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(bData,
                  ListItem(< con bytestring B:ByteString >)) =>
@@ -168,6 +174,7 @@ module UPLC-DATA-BUILTINS
   rule #typeCheck(ListItem(< con data{ _ } >), unConstrData, 1) => true
 
   rule <k> (builtin unConstrData) => < builtin unConstrData .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(unConstrData,
                  ListItem(< con data { Constr I:Int [ L:DataList ] } >)) =>
@@ -182,6 +189,7 @@ module UPLC-DATA-BUILTINS
   rule #typeCheck(ListItem(< con data{ _ } >), unMapData, 1) => true
 
   rule <k> (builtin unMapData) => < builtin unMapData .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(unMapData,
                  ListItem(< con data { Map [ L:DataPairList ] } >)) =>
@@ -196,6 +204,7 @@ module UPLC-DATA-BUILTINS
   rule #typeCheck(ListItem(< con data{ _ } >), unListData, 1) => true
 
   rule <k> (builtin unListData) => < builtin unListData .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(unListData,
                  ListItem(< con data { List [ L:DataList ] } >)) =>
@@ -210,6 +219,7 @@ module UPLC-DATA-BUILTINS
   rule #typeCheck(ListItem(< con data{ _ } >), unIData, 1) => true
 
   rule <k> (builtin unIData) => < builtin unIData .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(unIData,
                  ListItem(< con data { Integer I:Int } >)) =>
@@ -224,6 +234,7 @@ module UPLC-DATA-BUILTINS
   rule #typeCheck(ListItem(< con data{ _ } >), unBData, 1) => true
 
   rule <k> (builtin unBData) => < builtin unBData .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(unBData,
                  ListItem(< con data { ByteString B:ByteString } >)) =>
@@ -240,6 +251,7 @@ module UPLC-DATA-BUILTINS
   rule #typeCheck(ListItem(< con data{ _ } >)ListItem(< con data{ _ } >), equalsData, 2) => true
 
   rule <k> (builtin equalsData) => < builtin equalsData .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(equalsData,
                  (ListItem(< con data { T1:TextualData } >)
@@ -264,6 +276,7 @@ module UPLC-DATA-BUILTINS
   rule #typeCheck(ListItem(< con data{ _ } >)ListItem(< con data{ _ } >), mkPairData, 2) => true
 
   rule <k> (builtin mkPairData) => < builtin mkPairData .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(mkPairData,
                  (ListItem(< con data { T1:TextualData } >)
@@ -279,6 +292,7 @@ module UPLC-DATA-BUILTINS
   rule #typeCheck(ListItem(< con unit _ >), mkNilData, 1) => true
 
   rule <k> (builtin mkNilData) => < builtin mkNilData .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(mkNilData,
                  ListItem(< con unit () >)) =>
@@ -293,6 +307,7 @@ module UPLC-DATA-BUILTINS
   rule #typeCheck(ListItem(< con unit _ >), mkNilPairData, 1) => true
   
   rule <k> (builtin mkNilPairData) => < builtin mkNilPairData .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(mkNilPairData,
                  ListItem(< con unit () >)) =>

--- a/uplc-integer-builtins.md
+++ b/uplc-integer-builtins.md
@@ -18,6 +18,7 @@ module UPLC-INTEGER-BUILTINS
   rule #typeCheck(ListItem(< con integer _ >)ListItem(< con integer _ >), addInteger, 2) => true
 
   rule <k> (builtin addInteger) => < builtin addInteger .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(addInteger,
                      (ListItem(< con integer I1:Int >)
@@ -33,7 +34,9 @@ module UPLC-INTEGER-BUILTINS
   rule #typeCheck(ListItem(< con integer _ >), multiplyInteger, 1) => true
 
   rule #typeCheck(ListItem(< con integer _ >)ListItem(< con integer _ >), multiplyInteger, 2) => true
+
   rule <k> (builtin multiplyInteger) => < builtin multiplyInteger .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(multiplyInteger,
                      (ListItem(< con integer I1:Int >)
@@ -49,7 +52,9 @@ module UPLC-INTEGER-BUILTINS
   rule #typeCheck(ListItem(< con integer _ >), subtractInteger, 1) => true
 
   rule #typeCheck(ListItem(< con integer _ >)ListItem(< con integer _ >), subtractInteger, 2) => true
+
   rule <k> (builtin subtractInteger) => < builtin subtractInteger .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(subtractInteger,
                      (ListItem(< con integer I1:Int >)
@@ -70,6 +75,7 @@ mathematical integer division operation.
   rule #typeCheck(ListItem(< con integer _ >)ListItem(< con integer _ >), divideInteger, 2) => true
 
   rule <k> (builtin divideInteger) => < builtin divideInteger .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(divideInteger,
                      (ListItem(< con integer I1:Int >)
@@ -90,6 +96,7 @@ According to Plutus specification, `modInteger` implements standard mathematical
   rule #typeCheck(ListItem(< con integer _ >)ListItem(< con integer _ >), modInteger, 2) => true
 
   rule <k> (builtin modInteger) => < builtin modInteger .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(modInteger,
                      (ListItem(< con integer I1:Int >)
@@ -110,7 +117,9 @@ operator `/Int`  computes the quotient using t-division which rounds towards 0.
   rule #typeCheck(ListItem(< con integer _ >), quotientInteger, 1) => true
 
   rule #typeCheck(ListItem(< con integer _ >)ListItem(< con integer _ >), quotientInteger, 2) => true
+
   rule <k> (builtin quotientInteger) => < builtin quotientInteger .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(quotientInteger,
                      (ListItem(< con integer I1:Int >)
@@ -132,7 +141,9 @@ It cooresponds to Haskell rem, according to Plutus specification. From Haskell d
   rule #typeCheck(ListItem(< con integer _ >), remainderInteger, 1) => true
 
   rule #typeCheck(ListItem(< con integer _ >)ListItem(< con integer _ >), remainderInteger, 2) => true
+
   rule <k> (builtin remainderInteger) => < builtin remainderInteger .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(remainderInteger,
                      (ListItem(< con integer I1:Int >)
@@ -149,7 +160,9 @@ It cooresponds to Haskell rem, according to Plutus specification. From Haskell d
   rule #typeCheck(ListItem(< con integer _ >), lessThanInteger, 1) => true
 
   rule #typeCheck(ListItem(< con integer _ >)ListItem(< con integer _ >), lessThanInteger, 2) => true
+
   rule <k> (builtin lessThanInteger) => < builtin lessThanInteger .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(lessThanInteger,
                      (ListItem(< con integer I1:Int >)
@@ -173,8 +186,8 @@ It cooresponds to Haskell rem, according to Plutus specification. From Haskell d
 
   rule #typeCheck(ListItem(< con integer _ >)ListItem(< con integer _ >), lessThanEqualsInteger, 2) => true
 
-  rule <k> (builtin lessThanEqualsInteger) =>
-           < builtin lessThanEqualsInteger .List 2 > ... </k>
+  rule <k> (builtin lessThanEqualsInteger) => < builtin lessThanEqualsInteger .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(lessThanEqualsInteger,
                      (ListItem(< con integer I1:Int >)
@@ -198,8 +211,8 @@ It cooresponds to Haskell rem, according to Plutus specification. From Haskell d
 
   rule #typeCheck(ListItem(< con integer _ >)ListItem(< con integer _ >), equalsInteger, 2) => true
 
-  rule <k> (builtin equalsInteger) =>
-           < builtin equalsInteger .List 2 > ... </k>
+  rule <k> (builtin equalsInteger) => < builtin equalsInteger .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(equalsInteger,
                      (ListItem(< con integer I1:Int >)

--- a/uplc-polymorphic-builtins.md
+++ b/uplc-polymorphic-builtins.md
@@ -33,6 +33,7 @@ All polymorphic builtins should be arguments to a call to `force`.
          ifThenElse, 3) => true
 
   rule <k> (builtin ifThenElse) ~> Force => < builtin ifThenElse .List 3 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(ifThenElse,
                    (ListItem(< con bool True >)
@@ -55,6 +56,7 @@ All polymorphic builtins should be arguments to a call to `force`.
   rule #typeCheck(ListItem(< con unit () >) ListItem(_:Value) .List, chooseUnit, 2) => true
 
   rule <k> (builtin chooseUnit) ~> Force => < builtin chooseUnit .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(chooseUnit,
                    (ListItem(< con unit () >)
@@ -75,6 +77,7 @@ return an error if `fstPair`'s argument is not a pair.
                              fstPair, 1) => true
 
   rule <k> (builtin fstPair) ~> Force => < builtin fstPair .List 1 >  ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(fstPair,
               ListItem(< con pair (T1:TypeConstant) (_T2:TypeConstant)
@@ -95,6 +98,7 @@ return an error if `sndPair`'s argument is not a pair.
                              sndPair, 1) => true
 
   rule <k> (builtin sndPair) ~> Force => < builtin sndPair .List 1 >  ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(sndPair,
               ListItem(< con pair (_T1:TypeConstant) (T2:TypeConstant)
@@ -118,6 +122,7 @@ return an error if `sndPair`'s argument is not a pair.
                   chooseList, 3) => true
 
   rule <k> (builtin chooseList) ~> Force => < builtin chooseList .List 3 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(chooseList,
                      (ListItem(< con list(_T:TypeConstant) [ .ConstantList ] >)
@@ -142,6 +147,7 @@ return an error if `sndPair`'s argument is not a pair.
                   ListItem(< con list(T) [ _:ConstantList ] >), mkCons, 2) => true
 
   rule <k> (builtin mkCons) ~> Force => < builtin mkCons .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(mkCons,
               (ListItem(< con T:TypeConstant C:Constant >)
@@ -157,6 +163,7 @@ return an error if `sndPair`'s argument is not a pair.
   rule #typeCheck(ListItem(< con list(_:TypeConstant) [ _:ConstantList ] >), headList, 1) => true
 
   rule <k> (builtin headList) ~> Force => < builtin headList .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(headList,
               ListItem(< con list(T:TypeConstant)
@@ -172,6 +179,7 @@ return an error if `sndPair`'s argument is not a pair.
   rule #typeCheck(ListItem(< con list(_:TypeConstant) [ _:ConstantList ] >), tailList, 1) => true
 
   rule <k> (builtin tailList) ~> Force => < builtin tailList .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(tailList,
               ListItem(< con list(T:TypeConstant) [ .ConstantList ] >)) =>
@@ -190,6 +198,7 @@ return an error if `sndPair`'s argument is not a pair.
   rule #typeCheck(ListItem(< con list(_:TypeConstant) [ _:ConstantList ] >), nullList, 1) => true
 
   rule <k> (builtin nullList) ~> Force => < builtin nullList .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(nullList,
               ListItem(< con list(_T:TypeConstant) [ .ConstantList ] >)) =>
@@ -212,6 +221,7 @@ return an error if `sndPair`'s argument is not a pair.
                   ListItem(_:Value), trace, 2) => true
 
   rule <k> (builtin trace) ~> Force => < builtin trace .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(trace,
               (ListItem(< con string S >)

--- a/uplc-semantics.md
+++ b/uplc-semantics.md
@@ -42,29 +42,29 @@ module UPLC-SEMANTICS
   rule <k> (program _V M) => M </k>
 
   rule <k> X:UplcId => #lookup(RHO, X) ... </k>
-       <env> RHO </env>
+       <env> RHO => .Map </env>
   requires X in_keys(RHO)
 
   rule <k> X:UplcId => (error) ... </k>
        <env> RHO </env>
   requires notBool(X in_keys(RHO))
 
-  rule <k> (con T:TypeConstant C:Constant) =>
-           < con T:TypeConstant C:Constant > ... </k>
+  rule <k> (con T:TypeConstant C:Constant) => < con T:TypeConstant C:Constant > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> (lam X:UplcId M:Term) => < lam X M RHO > ... </k>
-       <env> RHO:Map </env>
+       <env> RHO => .Map </env>
 
   rule <k> (delay M:Term) => < delay M RHO > ... </k>
-       <env> RHO:Map </env>
+       <env> RHO => .Map </env>
 
   rule <k> (force M:Term) => (M ~> Force) ... </k>
 
   rule <k> < delay M:Term RHO:Map > ~> Force => M ... </k>
-       <env> _ => RHO:Map </env>
+       <env> _ => RHO </env>
 
   rule <k> [ M:Term TL:TermList ] => #app(M, TL, RHO) ... </k>
-       <env> RHO:Map </env>
+       <env> RHO </env>
 
   rule <k> V:Value ~> [_ M RHO:Map ] => M ~> [ V _] ... </k>
        <env> _ => RHO </env>

--- a/uplc-string-builtins.md
+++ b/uplc-string-builtins.md
@@ -20,6 +20,7 @@ module UPLC-STRING-BUILTINS
   rule #typeCheck(ListItem(< con string _ >), encodeUtf8, 1) => true
 
   rule <k> (builtin encodeUtf8) => < builtin encodeUtf8 .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(encodeUtf8, ListItem(< con string S:String >)) =>
            < con bytestring #encodeUtf8(S) > ... </k>
@@ -33,6 +34,7 @@ module UPLC-STRING-BUILTINS
   rule #typeCheck(ListItem(< con bytestring _ >), decodeUtf8, 1) => true
 
   rule <k> (builtin decodeUtf8) => < builtin decodeUtf8 .List 1 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(decodeUtf8, ListItem(< con bytestring B:ByteString >)) =>
            < con string #decodeUtf8(B) > ... </k>
@@ -48,6 +50,7 @@ module UPLC-STRING-BUILTINS
   rule #typeCheck(ListItem(< con string _ >)ListItem(< con string _ >), appendString, 2) => true
 
   rule <k> (builtin appendString) => < builtin appendString .List 2 > ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(appendString,
               (ListItem(< con string S1:String >)
@@ -65,6 +68,7 @@ module UPLC-STRING-BUILTINS
   rule #typeCheck(ListItem(< con string _ >)ListItem(< con string _ >), equalsString, 2) => true
 
   rule <k> (builtin equalsString) => < builtin equalsString .List 2 >  ... </k>
+       <env> _ => .Map </env>
 
   rule <k> #eval(equalsString,
               (ListItem(< con string S1:String >)


### PR DESCRIPTION
According to the CEK machine defined in the Plutus spec, the state
indicating the return phase does not contain an environment. By leaving
this cell alone, it's possible for the steps in the return phase to
maintain unneeded elements in `<Env>`. While this has no implications for
`kplc run`, this will make it difficult to write general claims. This
change rewrites the `<Env>` cell to `.Map` when the computation
transitions between the compute phase to the return phase for constants,
variables, lambda, delay, and builtin.