### PR TITLE
Add tests for True and False as variable names

### DIFF
--- a/tests/failing
+++ b/tests/failing
@@ -17,6 +17,9 @@ tests/textual/simple/var.uplc
 # remaining builtins and will not be included until we solve this.
 tests/textual/simple/addInteger-one-arg.uplc
 tests/textual/simple/addInteger-no-args.uplc
+# `uplc` allows `True` and `False` as variables.
+tests/textual/simple/true-var.uplc
+tests/textual/simple/false-var.uplc
 #
 # UPLC examples 
 #

--- a/tests/textual/simple/false-var.uplc
+++ b/tests/textual/simple/false-var.uplc
@@ -1,0 +1,1 @@
+(program 1.0.0 (lam False False))

--- a/tests/textual/simple/true-var.uplc
+++ b/tests/textual/simple/true-var.uplc
@@ -1,0 +1,1 @@
+(program 1.0.0 (lam True True))


### PR DESCRIPTION
- `uplc` allows for variables named `True` and `False`. This commit
  adds two tests, one for each case.

- It also adds two new entries to `tests/failing` until we rewrite the
  grammar to support that.