### PR TITLE
Updates to README and cabal files for native tokens generation

### DIFF
--- a/native-tokens/README.md
+++ b/native-tokens/README.md
@@ -1,4 +1,5 @@
 # How to generate a trivial native-tokens policy
+1. Install nix.
 1. Get IOG's `plutus` working on your system.
    - Clone Plutus commit ID: bcdd1ceffc93c733d90f5b89bcfae47d21dc2fcd.
    - Follow instructions at `https://github.com/input-output-hk/plutus#how-to-build-the-projects-artifacts` 
@@ -12,15 +13,15 @@
     # ...
    ] ++ (lib.optionals (!stdenv.isDarwin) [ rPackages.plotly R ]));
    ```
-1. Change to `plutus` directory and run `nix-shell`. Run the following steps inside `nix-shell`.
-2. Change to `plutus-semantics/native-tokens/native-tokens`.
-3. Run `cabal build`.
-4. Run `cabal run native-tokens-scripts out_scripts scripts`.
-5. There will be 5 flat format files in `out_scripts`.
-   In bash, run the following command. (Make sure 
-   `.../plutus/dist-newstyle/build/x86_64-linux/ghc-8.10.4.20210212/plutus-core-0.1.0.0/x/uplc/build/uplc/uplc` is in your `PATH`.)
+1. Change to `native-tokens/native-tokens`.
+1. Create a symbolic link from `plutus/shell.nix` to `native-tokens/native-tokens`.
+1. Run `nix-shell --command 'cabal build'`.
+1. Run `nix-shell --command 'cabal run native-tokens-scripts out_scripts scripts'`.
+1. There will be 5 flat format files in `out_scripts`.
+1. In bash, run the following command. (Make sure 
+   `plutus/dist-newstyle/build/x86_64-linux/ghc-8.10.4.20210212/plutus-core-0.1.0.0/x/uplc/build/uplc/uplc` is in your `PATH`.)
    ```shell
-   for i in out_scripts/*.flat ; do uplc convert --if flat -i $i --of textual -o $i.uplc ; done
+   for i in out_scripts/*.flat ; do uplc convert --if flat --of textual --print-mode Debug -i $i -o $i.debug.uplc ; done   
    ```
 
 Files `native-tokens/native-tokens/CompiledPolicy*.uplc` were

--- a/native-tokens/README.md
+++ b/native-tokens/README.md
@@ -14,11 +14,11 @@
    ] ++ (lib.optionals (!stdenv.isDarwin) [ rPackages.plotly R ]));
    ```
 1. Change to `native-tokens/native-tokens`.
-1. Create a symbolic link from `plutus/shell.nix` to `native-tokens/native-tokens`.
-1. Run `nix-shell --command 'cabal build'`.
-1. Run `nix-shell --command 'cabal run native-tokens-scripts out_scripts scripts'`.
-1. There will be 5 flat format files in `out_scripts`.
-1. In bash, run the following command. (Make sure 
+2. Create a symbolic link from `plutus/shell.nix` to `native-tokens/native-tokens`.
+3. Run `nix-shell --command 'cabal build'`.
+4. Run `nix-shell --command 'cabal run native-tokens-scripts out_scripts scripts'`.
+5. There will be 5 flat format files in `out_scripts`.
+6. In bash, run the following command. (Make sure 
    `plutus/dist-newstyle/build/x86_64-linux/ghc-8.10.4.20210212/plutus-core-0.1.0.0/x/uplc/build/uplc/uplc` is in your `PATH`.)
    ```shell
    for i in out_scripts/*.flat ; do uplc convert --if flat --of textual --print-mode Debug -i $i -o $i.debug.uplc ; done   

--- a/native-tokens/native-tokens/native-tokens.cabal
+++ b/native-tokens/native-tokens/native-tokens.cabal
@@ -139,7 +139,9 @@ executable native-tokens-scripts
     -Wincomplete-record-updates -Wredundant-constraints -Widentities
     -rtsopts -fobject-code -fno-ignore-interface-pragmas
     -fno-omit-interface-pragmas
-
+    -fplugin-opt PlutusTx.Plugin:no-simplifier-inline
+    -fplugin-opt PlutusTx.Plugin:no-simplifier-beta
+    
   --------------------
   -- Local components
   --------------------


### PR DESCRIPTION
* File `native-tokens/README.md` explains how to run the native tokens policy generation script without entering `nix-shell`.
* Two compiler options were added to `native-tokens.cabal`:

   ```
   -fplugin-opt PlutusTx.Plugin:no-simplifier-inline
   -fplugin-opt PlutusTx.Plugin:no-simplifier-beta
   ```

   They seem to help with code inlining in the context of this [thread](https://runtimeverification.slack.com/archives/C02P6HSCQQ2/p1660113867740209) and issue #[269](https://github.com/runtimeverification/plutus-core-semantics/issues/269).