### PR TITLE
Removing castToInt

### DIFF
--- a/simple-proofs/verification.md
+++ b/simple-proofs/verification.md
@@ -379,10 +379,11 @@ module AUXILIARIES
 ### `allInts(XS)`: capturing that `XS` is a list of integers
 
 ```k
-  syntax Bool ::= allInts(ConstantList) [function, functional]
+  syntax Bool ::= allInts(ConstantList) [function, functional, no-evaluators]
 
-  rule allInts(              .ConstantList) => true
-  rule allInts(C:Constant, XS:ConstantList) => isInt(C) andBool allInts(XS)
+  rule { true #Equals allInts(              .ConstantList) } => #Top [simplification]
+  rule { true #Equals allInts(C:Constant, XS:ConstantList) } => #Exists I:Int. { C #Equals I } #And { true #Equals allInts(XS) }
+    [simplification, unboundVariables(I)]
 ```
 
 ### `sum(XS)`: calculating the sum of a given list of integers `XS`

--- a/uplc-integer-builtins.md
+++ b/uplc-integer-builtins.md
@@ -10,27 +10,13 @@ module UPLC-INTEGER-BUILTINS
   rule #expectedArguments(_BN::IntegerBuiltinName) => ListItem(integer) ListItem(integer)
 ```
 
-```symbolic
-  syntax KItem ::= castToInt(Constant)
-  rule <k> castToInt(_:Int)      => .       ... </k>
-  rule <k> castToInt(C:Constant) => (error) ... </k> ensures notBool isInt(C) [owise]
-```
-
 ## `addInteger`
 
-```concrete
+```k
   rule <k> #eval(addInteger,
                      (ListItem(< con integer I1:Int >)
                       ListItem(< con integer I2:Int >))) =>
            < con integer I1 +Int I2 > ... </k>
-```
-
-```symbolic
-  rule <k> #eval(addInteger,
-                     (ListItem(< con integer C1:Constant >)
-                      ListItem(< con integer C2:Constant >))) =>
-           castToInt(C1) ~> castToInt(C2) ~>
-               < con integer { C1 }:>Int +Int { C2 }:>Int > ... </k>
 ```
 
 ## `multiplyInteger`


### PR DESCRIPTION
The castToInt trick will no longer be needed once https://github.com/runtimeverification/haskell-backend/pull/3202 is merged into the Haskell backend.

The `allInts(XS)` predicate is changed so that the associated reasoning happens at the ML-level.