### PR TITLE
Build system refactors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,13 @@ haskell_kompiled       := $(haskell_dir)/$(haskell_main_filename)-kompiled/defin
 
 KOMPILE_OPTS += --no-exc-wrap
 
+ifneq ($(RELEASE),)
+    KOMPILE_OPTS += -O3
+    LLVM_KOMPILE_OPTS += -ccopt -O3
+else
+    LLVM_KOMPILE_OPTS += -ccopt -g
+endif
+
 ifndef NOBUILD_CRYPTOPP
   $(KPLUTUS_LIB)/$(llvm_kompiled): $(libcryptopp_out)
 endif
@@ -273,7 +280,7 @@ $(KPLUTUS_LIB)/$(llvm_kompiled): $(kplutus_includes) $(plugin_includes) $(plugin
 	    $(llvm_main_file)                     \
 	    --main-module $(llvm_main_module)     \
 	    --syntax-module $(llvm_syntax_module) \
-	    $(KOMPILE_OPTS)
+	    $(KOMPILE_OPTS) $(LLVM_KOMPILE_OPTS)
 
 $(KPLUTUS_LIB)/$(haskell_kompiled): $(kplutus_includes) $(plugin_includes) $(KPLUTUS_BIN)/kplc
 	$(KOMPILE) --backend haskell                     \

--- a/Makefile
+++ b/Makefile
@@ -403,7 +403,7 @@ simple-proofs/%.md.prove: simple-proofs/%.md simple-proofs/verification/haskell/
 	$(KPLUTUS) prove --directory simple-proofs/verification/haskell $< $(KPROVE_OPTS)
 
 simple-proofs/verification/haskell/verification-kompiled/timestamp: simple-proofs/verification.md $(kplutus_includes)
-	$(KOMPILE) --symbolic --backend haskell $< --directory simple-proofs/verification/haskell
+	$(KOMPILE) --backend haskell $< --directory simple-proofs/verification/haskell
 
 
 # Testing

--- a/kplc
+++ b/kplc
@@ -3,11 +3,6 @@
 set -euo pipefail
 shopt -s extglob
 
-debug=false
-verbose=false
-flat_format=false
-symbolic=false
-
 notif() {
     if ${verbose}; then
         echo "== $0 [$(date)]: $@" >&2
@@ -149,6 +144,10 @@ backend='llvm'
 bug_report=false
 debugger=false
 pyk=false
+debug=false
+verbose=false
+flat_format=false
+symbolic=false
 
 args=()
 while [[ $# -gt 0 ]]; do

--- a/kplc
+++ b/kplc
@@ -41,36 +41,36 @@ run_kplutus_pyk() {
 
 run_kompile() {
     local kompile_opts
-    local execution_type
 
-    if [[ ${backend} == 'haskell' ]]; then
-        execution_type="symbolic"
-    else
-        execution_type="concrete"
-    fi
+    kompile_opts=( "${run_file}" --directory "${backend_dir}" --backend "${backend}"     )
+    kompile_opts+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
+    kompile_opts+=( --hook-namespaces "KRYPTO"                                           )
+    kompile_opts+=( --emit-json                                                          )
 
-    kompile_opts=( "${run_file}" --directory "${backend_dir}" --backend "${backend}"              )
-    kompile_opts+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework"          )
-    kompile_opts+=( --md-selector "k | libcrypto-extra | ${execution_type}"                       )
-    kompile_opts+=( --hook-namespaces "KRYPTO"                                                    )
-    kompile_opts+=( --emit-json                                                                   )
-    kompile_opts+=( -ccopt -L${libff_dir}/lib -ccopt -I${libff_dir}/include                       )
-    kompile_opts+=( -ccopt ${plugin_include}/c/plugin_util.cpp                                    )
-    kompile_opts+=( -ccopt ${plugin_include}/c/crypto.cpp                                         )
-    kompile_opts+=( -ccopt ${plugin_include}/c/hash_ext.cpp                                       )
-    kompile_opts+=( -ccopt ${plugin_include}/c/blake2.cpp                                         )
-    kompile_opts+=( -ccopt -g -ccopt -std=c++14                                                   )
-    kompile_opts+=( -ccopt -lff -ccopt -lcryptopp -ccopt -lsecp256k1 -ccopt -lssl -ccopt -lcrypto )
-    if [[ "$(uname -s)" == 'Linux' ]]; then
-        kompile_opts+=( -ccopt -lprocps )
-    elif [[ "$(uname -s)" == 'Darwin' ]]; then
-        openssl_root="$(brew --prefix openssl)"
-        brew_root="$(brew --prefix)"
-        kompile_opts+=( -ccopt -I${brew_root}/include -ccopt -L/${brew_root}/lib -ccopt -I${openssl_root}/include -ccopt -L${openssl_root}/lib )
-    fi
-    if [[ -d ${libcryptopp_dir} ]]; then
-        kompile_opts+=( -ccopt -I${libcryptopp_dir}/include -ccopt -L/${libcryptopp_dir}/lib )
-    fi
+    case "${backend}" in
+        haskell) kompile_opts+=( --md-selector "k | libcrypto-extra | symbolic" )
+                 ;;
+        llvm)    kompile_opts+=( --md-selector "k | libcrypto-extra | concrete"                                )
+                 kompile_opts+=( -ccopt -L${libff_dir}/lib -ccopt -I${libff_dir}/include                       )
+                 kompile_opts+=( -ccopt ${plugin_include}/c/plugin_util.cpp                                    )
+                 kompile_opts+=( -ccopt ${plugin_include}/c/crypto.cpp                                         )
+                 kompile_opts+=( -ccopt ${plugin_include}/c/hash_ext.cpp                                       )
+                 kompile_opts+=( -ccopt ${plugin_include}/c/blake2.cpp                                         )
+                 kompile_opts+=( -ccopt -g -ccopt -std=c++14                                                   )
+                 kompile_opts+=( -ccopt -lff -ccopt -lcryptopp -ccopt -lsecp256k1 -ccopt -lssl -ccopt -lcrypto )
+                 if [[ "$(uname -s)" == 'Linux' ]]; then
+                     kompile_opts+=( -ccopt -lprocps )
+                 elif [[ "$(uname -s)" == 'Darwin' ]]; then
+                     openssl_root="$(brew --prefix openssl)"
+                     brew_root="$(brew --prefix)"
+                     kompile_opts+=( -ccopt -I${brew_root}/include -ccopt -L/${brew_root}/lib -ccopt -I${openssl_root}/include -ccopt -L${openssl_root}/lib )
+                 fi
+                 if [[ -d ${libcryptopp_dir} ]]; then
+                     kompile_opts+=( -ccopt -I${libcryptopp_dir}/include -ccopt -L/${libcryptopp_dir}/lib )
+                 fi
+                 ;;
+        *)       fatal "Unknown backend for kompile: ${backend}" ;;
+    esac
 
     if ${pyk}; then
         run_kplutus_pyk kompile "${kompile_opts[@]}" "$@"

--- a/kplc
+++ b/kplc
@@ -133,12 +133,6 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
     exit 0
 fi
 
-if [[ "$run_command" == 'version' ]] || [[ "$run_command" == '--version' ]]; then
-    notif 'KPlutus Version'
-    cat $INSTALL_LIB/version
-    exit 0
-fi
-
 result_only=false
 backend='llvm'
 bug_report=false
@@ -163,6 +157,12 @@ while [[ $# -gt 0 ]]; do
         *)              args+=("$1")                    ; shift   ;;
     esac
 done
+
+if [[ "$run_command" == 'version' ]] || [[ "$run_command" == '--version' ]]; then
+    notif 'KPlutus Version'
+    cat $INSTALL_LIB/version
+    exit 0
+fi
 
 [[ "${#args[@]}" -le 0 ]] || set -- "${args[@]}"
 backend_dir="${backend_dir:-$INSTALL_LIB/$backend}"

--- a/kplc
+++ b/kplc
@@ -56,7 +56,7 @@ run_kompile() {
                  kompile_opts+=( -ccopt ${plugin_include}/c/crypto.cpp                                         )
                  kompile_opts+=( -ccopt ${plugin_include}/c/hash_ext.cpp                                       )
                  kompile_opts+=( -ccopt ${plugin_include}/c/blake2.cpp                                         )
-                 kompile_opts+=( -ccopt -g -ccopt -std=c++14                                                   )
+                 kompile_opts+=( -ccopt -std=c++14                                                             )
                  kompile_opts+=( -ccopt -lff -ccopt -lcryptopp -ccopt -lsecp256k1 -ccopt -lssl -ccopt -lcrypto )
                  if [[ "$(uname -s)" == 'Linux' ]]; then
                      kompile_opts+=( -ccopt -lprocps )

--- a/kplc
+++ b/kplc
@@ -43,7 +43,7 @@ run_kompile() {
     local kompile_opts
     local execution_type
 
-    if [[ ${symbolic} == true ]]; then
+    if [[ ${backend} == 'haskell' ]]; then
         execution_type="symbolic"
     else
         execution_type="concrete"
@@ -147,7 +147,6 @@ pyk=false
 debug=false
 verbose=false
 flat_format=false
-symbolic=false
 
 args=()
 while [[ $# -gt 0 ]]; do
@@ -160,7 +159,6 @@ while [[ $# -gt 0 ]]; do
         --result-only)  result_only=true                ; shift   ;;
         --bug-report)   bug_report=true                 ; shift   ;;
         --debugger)     debugger=true                   ; shift   ;;
-        --symbolic)     symbolic=true                   ; shift   ;;
         --pyk)          pyk=true                        ; shift   ;;
         *)              args+=("$1")                    ; shift   ;;
     esac


### PR DESCRIPTION
Here's a quick little PR that adjusts `kplc kompile` to only pass llvm specific arguments when the backend to kompile for is llvm, and keeps debug/release related options only in their own respective build profiles.