### PR TITLE
Fix compilation options in `native-tokens.cabal` and `stablecoin.cabal`

### DIFF
--- a/IOG-contracts/native-tokens/native-tokens/native-tokens.cabal
+++ b/IOG-contracts/native-tokens/native-tokens/native-tokens.cabal
@@ -57,6 +57,8 @@ library
     -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wredundant-constraints -Widentities -fobject-code
     -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
+    -fplugin-opt PlutusTx.Plugin:no-simplifier-inline
+    -fplugin-opt PlutusTx.Plugin:no-simplifier-beta
 
   --------------------
   -- Local components
@@ -140,8 +142,6 @@ executable native-tokens-scripts
     -Wincomplete-record-updates -Wredundant-constraints -Widentities
     -rtsopts -fobject-code -fno-ignore-interface-pragmas
     -fno-omit-interface-pragmas
-    -fplugin-opt PlutusTx.Plugin:no-simplifier-inline
-    -fplugin-opt PlutusTx.Plugin:no-simplifier-beta
 
   --------------------
   -- Local components

--- a/IOG-contracts/stablecoin/stablecoin/stablecoin.cabal
+++ b/IOG-contracts/stablecoin/stablecoin/stablecoin.cabal
@@ -54,6 +54,8 @@ library
     -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wredundant-constraints -Widentities -fobject-code
     -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
+    -fplugin-opt PlutusTx.Plugin:no-simplifier-inline
+    -fplugin-opt PlutusTx.Plugin:no-simplifier-beta
 
   --------------------
   -- Local components
@@ -117,8 +119,6 @@ executable stablecoin-scripts
     -Wincomplete-record-updates -Wredundant-constraints -Widentities
     -rtsopts -fobject-code -fno-ignore-interface-pragmas
     -fno-omit-interface-pragmas
-    -fplugin-opt PlutusTx.Plugin:no-simplifier-inline
-    -fplugin-opt PlutusTx.Plugin:no-simplifier-beta
 
   --------------------
   -- Local components


### PR DESCRIPTION
- Compilation options
  ```
  -fplugin-opt PlutusTx.Plugin:no-simplifier-inline
  -fplugin-opt PlutusTx.Plugin:no-simplifier-beta
  ```
  should be under `ghc-options` for the library targets in `.cabal` files.