### PR TITLE
Add `gen-bison-parser` to KOMPILE_OPTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,13 @@ endif
 build-llvm-profiling: KOMPILE_OPTS += -O3 -ccopt -fno-omit-frame-pointer
 build-llvm-profiling: $(KPLUTUS_LIB)/$(llvm_kompiled)
 
+bison_version    := $(shell eval "bison --version | head -n1 | sed 's/bison (GNU Bison) //g'")
+smallest_version := $(shell echo "$(bison_version)\n3.7.4" | sort -V | head -n1)
+
+ifeq ($(smallest_version), 3.7.4)
+	LLVM_KOMPILE_OPTS+=--gen-bison-parser
+endif 
+
 $(KPLUTUS_LIB)/$(llvm_kompiled): $(kplutus_includes) $(plugin_includes) $(plugin_c_includes) $(libff_out) $(KPLUTUS_BIN)/kplc
 	$(KOMPILE) --backend llvm                 \
 	    $(llvm_main_file)                     \


### PR DESCRIPTION
- The `gen-bison-parser` option generates a more efficient parser
  based on `bison`. To add this option we need to make sure our
  grammar is LR(1), which seems to be the case, and that bison's
  version is greater or equal to 3.7.4.

- This commit adds the `gen-bison-parser` option to KOMPILE_OPTS
  should bison's version fulfill the version requirement above.