### PR TITLE
Fix bison flag and update k image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG K_COMMIT
-FROM runtimeverificationinc/kframework-k:ubuntu-focal-${K_COMMIT}
+FROM runtimeverificationinc/kframework-k:ubuntu-jammy-${K_COMMIT}
 
 RUN    apt-get update            \
     && apt-get upgrade --yes     \
@@ -21,7 +21,7 @@ RUN    apt-get update            \
 
 RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.11 \
     && cd z3                                                         \
-    && python scripts/mk_make.py                                     \
+    && python3 scripts/mk_make.py                                    \
     && cd build                                                      \
     && make -j8                                                      \
     && make install                                                  \

--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ build-llvm-profiling: KOMPILE_OPTS += -O3 -ccopt -fno-omit-frame-pointer
 build-llvm-profiling: $(KPLUTUS_LIB)/$(llvm_kompiled)
 
 bison_version    := $(shell eval "bison --version | head -n1 | sed 's/bison (GNU Bison) //g'")
-smallest_version := $(shell echo "$(bison_version)\n3.7.4" | sort -V | head -n1)
+smallest_version := $(shell echo -e "$(bison_version)\n3.7.4" | sort -V | head -n1)
 
 ifeq ($(smallest_version), 3.7.4)
 	LLVM_KOMPILE_OPTS+=--gen-bison-parser

--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ build-llvm-profiling: KOMPILE_OPTS += -O3 -ccopt -fno-omit-frame-pointer
 build-llvm-profiling: $(KPLUTUS_LIB)/$(llvm_kompiled)
 
 bison_version    := $(shell eval "bison --version | head -n1 | sed 's/bison (GNU Bison) //g'")
-smallest_version := $(shell echo -e "$(bison_version)\n3.7.4" | sort -V | head -n1)
+smallest_version := $(shell printf "$(bison_version)\n3.7.4" | sort -V | head -n1)
 
 ifeq ($(smallest_version), 3.7.4)
 	LLVM_KOMPILE_OPTS+=--gen-bison-parser


### PR DESCRIPTION
This PR fixes the bison flag check and upates K image from focal to Jammy. By doing so, we can use a newer version of bison for kompile's `--gen-bison-parser` option.