### PR TITLE
README: update Ubuntu packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Dependencies
 ### Ubuntu
 
 ```
-sudo apt-get install build-essential m4 openjdk-11-jdk libgmp-dev libmpfr-dev pkg-config flex bison z3 libsecp256k1-dev libz3-dev maven python3 python3-pip cmake gcc clang-10 lld-10 llvm-10-tools zlib1g-dev libboost-test-dev libyaml-dev libjemalloc-dev libsecp256k1-dev libssl-dev xxd
+sudo apt-get install build-essential m4 openjdk-11-jdk libgmp-dev libmpfr-dev pkg-config flex bison z3 libsecp256k1-dev libz3-dev maven python3 python3-dev python3-pip cmake gcc clang-10 lld-10 llvm-10-tools zlib1g-dev libboost-test-dev libyaml-dev libjemalloc-dev libsecp256k1-dev libssl-dev xxd
 pip install virtualenv poetry
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Dependencies
 -   Update submodules: `git submodule update --init --recursive`
 -   Make dependencies: `make deps RELEASE=true`
 
-### Ubuntu
+### Ubuntu (20.04 Focal, 22.04 Jammy)
 
 ```
-sudo apt-get install build-essential m4 openjdk-11-jdk libgmp-dev libmpfr-dev pkg-config flex bison z3 libsecp256k1-dev libz3-dev maven python3 python3-dev python3-pip cmake gcc clang-10 lld-10 llvm-10-tools zlib1g-dev libboost-test-dev libyaml-dev libjemalloc-dev libsecp256k1-dev libssl-dev xxd
+sudo apt-get install build-essential m4 openjdk-11-jdk libgmp-dev libmpfr-dev pkg-config flex bison z3 libsecp256k1-dev libz3-dev maven python3 python3-dev python3-pip cmake gcc clang-12 lld-12 llvm-12-tools zlib1g-dev libboost-test-dev libyaml-dev libjemalloc-dev libsecp256k1-dev libssl-dev xxd
 pip install virtualenv poetry
 ```
 


### PR DESCRIPTION
Since the KLLVM python bindings have been added, the Python development headers are a requirement to build K. This PR adds them to the suggested Ubuntu packages.

Additionally, we no longer recommend using LLVM 10 in package lists as it's not present on Ubuntu Jammy. This PR bumps the recommended version to 12.

The upstream K PR that these changes are derived from is: https://github.com/runtimeverification/k/pull/2891.