### PR TITLE
Uplc emacs mode

### DIFF
--- a/binsearch/README.md
+++ b/binsearch/README.md
@@ -1,0 +1,26 @@
+# Binary search in UPLC
+
+- File `binarysearch.md` constains the fixpoint operator `REC` and the
+  recursive definition of binary search, implemented using 3 aliases:
+  function, function body, function loop.
+
+- File `verification.md` only includes UPLC and binary search syntax.
+
+- File `binarysearch-unit-tests.md` defines some claims.
+
+- To check claims:  
+  1. Compile `verification.md`  
+    ```shell
+    deps/k/k-distribution/bin/kompile --backend haskell \
+                                      --directory binsearch/verification/haskell \
+                                      binsearch/verification.md \
+                                      -I /data/RV/plutus-core-semantics/.build/usr/lib/kplutus/include/kframework \
+                                      -I /data/RV/plutus-core-semantics/.build/usr/lib/kplutus/blockchain-k-plugin/include/kframework
+    ```
+  2. Run the prover on the claims.  
+    ```shell
+    deps/k/k-distribution/bin/kprove --directory binsearch/verification/haskell \
+                                     binsearch/binsearch-unit-test.md \
+                                     -I /data/RV/plutus-core-semantics/.build/usr/lib/kplutus/include/kframework \
+                                     -I /data/RV/plutus-core-semantics/.build/usr/lib/kplutus/blockchain-k-plugin/include/kframework
+    ```

--- a/binsearch/binsearch-unit-test.md
+++ b/binsearch/binsearch-unit-test.md
@@ -1,0 +1,89 @@
+```k
+requires "verification.md"
+
+module BINSEARCH-UNIT-TEST
+  imports VERIFICATION
+    claim <k> [ BINSEARCH_REC
+                (con list(integer)
+                  [ 1 ,
+                    [ 2 , [ .ConstantList ] , [ .ConstantList ] , .ConstantList ],
+                    [ 3 , [ .ConstantList ] , [ .ConstantList ] , .ConstantList ],
+                    .ConstantList
+                  ]
+                 )
+               (con integer 1) ]
+          => (con bool True) ...
+          </k>
+    <env> .Map </env>
+    
+    claim <k>
+      [ ( force ( builtin tailList ) )
+        ( con list ( integer )
+          [ 1 ,
+            [ 4 ,
+              [ 5 , [ .ConstantList ], [ .ConstantList ], .ConstantList ],
+              [ 6 , [ .ConstantList ], [ .ConstantList ], .ConstantList ],
+              .ConstantList
+            ],
+            [ 3 , [ .ConstantList ], [ .ConstantList ], .ConstantList ],
+            .ConstantList
+          ]
+        )
+      ]
+    =>
+     < con list(integer)
+       [ 
+         [ 4 ,
+           [ 5 , [ .ConstantList ] , [ .ConstantList ] , .ConstantList ] ,
+           [ 6 , [ .ConstantList ] , [ .ConstantList ] , .ConstantList ] ,
+           .ConstantList
+         ] ,
+         [ 3 , [ .ConstantList ] , [ .ConstantList ] , .ConstantList ] ,
+         .ConstantList
+       ]
+     > ...
+  </k>
+  <env> .Map </env>
+
+  claim <k>
+      [ ( force ( builtin headList ) )
+        ( con list ( integer )
+          [ 1 ,
+            [ 4 ,
+              [ 5 , [ .ConstantList ], [ .ConstantList ], .ConstantList ],
+              [ 6 , [ .ConstantList ], [ .ConstantList ], .ConstantList ],
+              .ConstantList
+            ],
+            [ 3 , [ .ConstantList ], [ .ConstantList ], .ConstantList ],
+            .ConstantList
+          ]
+        )
+      ]
+    =>
+     < con integer 1 >  ...
+  </k>
+  <env> .Map </env>
+
+  claim <k>
+      [ ( force ( builtin tailList ) )
+        ( con list ( integer )
+          [ _I:Int , CL:ConstantList ]
+        )
+      ]
+    =>
+     < con list(integer) [ CL ] > ...
+  </k>
+  <env> .Map </env>
+
+  claim <k>
+      [ ( force ( builtin headList ) )
+        ( con list ( integer )
+          [ I:Int , _CL:ConstantList ]
+        )
+      ]
+    =>
+     < con integer I > ...
+  </k>
+  <env> .Map </env>
+endmodule
+```

--- a/binsearch/binsearch.md
+++ b/binsearch/binsearch.md
@@ -1,0 +1,60 @@
+```k
+requires "uplc.md"
+
+module REC
+  imports UPLC-SYNTAX
+  syntax Term ::= "REC" [alias]
+  rule REC => (lam f_0
+                [ (lam s_0 [ s_0 s_0 ])
+                  (lam s_0 (lam x_0 [ [ f_0 [ s_0 s_0 ] ] x_0 ])) ])
+endmodule
+
+module BINSEARCH
+  imports REC
+  imports UPLC-SYNTAX
+  
+  syntax Term ::= "BINSEARCH" [alias]
+  syntax Term ::= "BINSEARCH_REC" [alias]
+  syntax Term ::= "BINSEARCH_BODY" [alias]
+  syntax Term ::= "BINSEARCH_LOOP" [alias]
+  syntax Term ::= "HEAD" [alias]
+  syntax Term ::= "TAIL" [alias]
+  syntax Term ::= "LEFT_TREE" [alias]
+  syntax Term ::= "RIGHT_TREE" [alias]
+
+  rule BINSEARCH_REC => [ REC BINSEARCH ]
+
+  rule BINSEARCH => (lam bin_search BINSEARCH_BODY)
+
+  rule BINSEARCH_BODY => (lam in_list (lam in_e BINSEARCH_LOOP))
+
+  rule HEAD => (force (builtin headList))
+
+  rule TAIL => (force (builtin tailList))
+
+  rule LEFT_TREE => [ HEAD [ TAIL in_list ] ]
+
+  rule RIGHT_TREE => [ HEAD [ TAIL [ TAIL in_list ] ] ]
+
+  rule BINSEARCH_LOOP =>
+    (force
+      [ (force (builtin ifThenElse))
+        [ (force (builtin nullList)) in_list ]
+        ( delay (con bool False) )
+        ( delay
+          (force
+            [ (force (builtin ifThenElse))
+              [ (force (builtin equalsInteger)) in_e [ HEAD in_list ] ]
+              (delay (con bool True))
+              [ (force (builtin ifThenElse))
+                [ (force (builtin lessThanInteger)) in_e HEAD ]
+                (delay [ bin_search LEFT_TREE in_e ] )
+                (delay [ bin_search RIGHT_TREE in_e ] )
+              ]
+            ]
+          )
+        )
+      ]
+    )
+endmodule
+```

--- a/binsearch/verification.md
+++ b/binsearch/verification.md
@@ -1,0 +1,9 @@
+```k
+requires "uplc.md"
+requires "binsearch.md"
+
+module VERIFICATION
+  imports UPLC
+  imports BINSEARCH
+endmodule
+```

--- a/uplc-mode.el
+++ b/uplc-mode.el
@@ -1,0 +1,56 @@
+;;(require 'generic-x) ;; we need this
+
+(define-generic-mode 
+  'uplc-mode                        ;; name of the mode to create
+  '("#")                            ;; comments start with '#' 
+  '("lam" "builtin" "program"
+    "force" "delay" "con"
+    "Constr" "Map" "List"
+    "Integer" "ByteString")         ;; some keywords
+  '(("\\[" . 'font-lock-preprocessor-face)     ;; '[' is an operator
+    ("\\]" . 'font-lock-preprocessor-face)     ;; ']' is an operator
+    ;; Version constant
+    ("[0-9]+.[0-9]+.[0-9]+" . 'font-lock-constant-face)
+    ;; Type constants
+    ("integer\\|data\\|bytestring\\|string\\|unit\\|bool\\|list\\|pair"
+     .
+     'font-lock-type-face)
+    ;; Builtin for Integers
+    ("addInteger\\|subtractInteger\\|multiplyInteger\\|divideInteger\\|quotientInteger\\|remainderInteger\\|modInteger\\|equalsInteger\\|lessThanInteger\\|lessThanEqualsInteger"
+     .
+     'font-lock-builtin-face)
+    ;; Builtin for ByteStrings
+    ("appendByteString\\|consByteString\\|sliceByteString\\|lengthOfByteString\\|indexByteString\\|equalsByteString\\|lessThanByteString\\|lessThanEqualsByteString"
+     .
+     'font-lock-builtin-face)
+    ;; Builtin for crypto
+    ("sha2_256\\|sha3_256\\|blake2b_256\\|verifySignature"
+     .
+     'font-lock-builtin-face)
+    ;; Builtin for Strings
+    ("appendString\\||equalsString\\|encodeUtf8\\|decodeUtf8"
+     .
+     'font-lock-builtin-face)
+    ;; Polymorphic builtins
+    ("ifThenElse\\|chooseUnit\\|trace"
+     .
+     'font-lock-builtin-face)
+    ;; Builtin for pairs
+    ( "fstPair\\|sndPair"
+     .
+     'font-lock-builtin-face)
+    ;; Builtin for lists
+    ("chooseList\\|mkCons\\|headList\\|tailList\\|nullList"
+     .
+     'font-lock-builtin-face)
+    ;; Data builtins
+    ("chooseData\\|constrData\\|mapData\\|listData\\|iData\\|bData\\|unConstrData\\|unMapData\\|unListData\\|unIData\\|unBData\\|equalsData\\|mkPairData\\|mkNilData\\|mkNilPairData"
+     .
+     'font-lock-builtin-face)
+    ("[a-z][a-zA-Z0-9]*\\(_\\([0-9]+\\|[a-zA-Z]+\\)\\)*"
+     .
+     'font-lock-variable-name-face))           
+  '("\\.uplc$")                     ;; files for which to activate this mode 
+   nil                              ;; other functions to call
+  "A mode for UPLC files."          ;; doc string for this mode
+)


### PR DESCRIPTION
- Add `uplc-mode.el` implementing a simple Emacs major mode for UPLC. 
- At the moment only syntax-highlighting is supported. 