### PR TITLE
Log level to error on CI while proving simple

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -30,7 +30,7 @@ jobs:
       - name: 'Test simple'
         run: docker exec -t kplutus-ci-${GITHUB_SHA} /bin/bash -c 'make test-simple -j`nproc` --output-sync=recurse'
       - name: 'Test proofs'
-        run: docker exec -t kplutus-ci-${GITHUB_SHA} /bin/bash -c 'export KORE_EXEC_OPTS=\"--log-level error\" && make test-prove -j`nproc` --output-sync=recurse'
+        run: docker exec -t kplutus-ci-${GITHUB_SHA} /bin/bash -c 'export KORE_EXEC_OPTS="--log-level error" && make test-prove -j`nproc` --output-sync=recurse'
       - name: 'Test uplc-examples'
         run: docker exec -t kplutus-ci-${GITHUB_SHA} /bin/bash -c 'make test-uplc-examples -j`nproc` --output-sync=recurse'
       - name: 'Test benchmark-validation-examples'

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -30,7 +30,7 @@ jobs:
       - name: 'Test simple'
         run: docker exec -t kplutus-ci-${GITHUB_SHA} /bin/bash -c 'make test-simple -j`nproc` --output-sync=recurse'
       - name: 'Test proofs'
-        run: docker exec -t kplutus-ci-${GITHUB_SHA} /bin/bash -c 'make test-prove -j`nproc` --output-sync=recurse'
+        run: docker exec -t kplutus-ci-${GITHUB_SHA} /bin/bash -c 'export KORE_EXEC_OPTS=\"--log-level error\" && make test-prove -j`nproc` --output-sync=recurse'
       - name: 'Test uplc-examples'
         run: docker exec -t kplutus-ci-${GITHUB_SHA} /bin/bash -c 'make test-uplc-examples -j`nproc` --output-sync=recurse'
       - name: 'Test benchmark-validation-examples'


### PR DESCRIPTION
- Changes `make test-prove` action on CI to consider  `KORE_EXEC_OPTS="--log-level error"` as in the current version of
  the Haskell backend `trivial-policies.md` is generating a ~100MB log message.